### PR TITLE
PERF: Applying patch suggested by OTB mantis issue #257

### DIFF
--- a/src/projection/ossimSensorModel.cpp
+++ b/src/projection/ossimSensorModel.cpp
@@ -411,9 +411,9 @@ void ossimSensorModel::worldToLineSample(const ossimGpt& worldPoint,
       //***
       // Compute numerical partials at current guessed point:
       //***
-      lineSampleToWorld(ip,    height, gp);
-      lineSampleToWorld(ip_du, height, gp_du);
-      lineSampleToWorld(ip_dv, height, gp_dv);
+      lineSampleToWorld(ip,    gp);
+      lineSampleToWorld(ip_du, gp_du);
+      lineSampleToWorld(ip_dv, gp_dv);
 
       if(gp.isLatNan() || gp.isLonNan())
       {

--- a/src/projection/ossimSensorModel.cpp
+++ b/src/projection/ossimSensorModel.cpp
@@ -411,9 +411,9 @@ void ossimSensorModel::worldToLineSample(const ossimGpt& worldPoint,
       //***
       // Compute numerical partials at current guessed point:
       //***
-      lineSampleHeightToWorld(ip,    height, gp);
-      lineSampleHeightToWorld(ip_du, height, gp_du);
-      lineSampleHeightToWorld(ip_dv, height, gp_dv);
+      lineSampleToWorld(ip,    height, gp);
+      lineSampleToWorld(ip_du, height, gp_du);
+      lineSampleToWorld(ip_dv, height, gp_dv);
 
       if(gp.isLatNan() || gp.isLonNan())
       {


### PR DESCRIPTION
https://bugs.orfeo-toolbox.org/view.php?id=257

Hi all,

When dealing with sensor models (in my case a TerraSar-X sensor
model), I've noticed that the application of a forward projection
(image to world coordinates) followed by an inverse projection (world
to image coordinates) leads to an unexpected result... that is, we
don't land on our feet ! The resulting image coordinates are (in my
case) 10 pixels far from the initial image coordinates.

In the method ossimSensorModel::worldToLineSample, the method
lineSampleHeightToWorld is iteratively called with a fixed height (the
height of the world point given as argument of
ossimSensorModel::worldToLineSample) what I think is not correct.
I've run tests where I replaced calls to lineSampleHeightToWorld with
calls to lineSampleToWorld (lines 346, 347 & 348 of file
ossimSensorModel.cpp) and the results are much better (the resulting
image coordinates are less than 0.1 pixel far from the initial ones).

The call to lineSampleHeightToWorld could be a voluntary choice made
by the software developer in order to have a less time-consuming
method (?). Indeed, lineSampleToWorld implements an iterative
intersection between a ray and the DEM whereas lineSampleHeightToWorld
does not.
However, I think it's worth it because the location accuracy (from
world to image) would be (greatly) improved.

You can find the suggested modification in attached file.

Thank you for your answers,

Best regards,

Edouard