### PR TITLE
Fix regression on `addNode`, `findChildNodes`... [c13b1d7]

### DIFF
--- a/src/base/ossimXmlNode.cpp
+++ b/src/base/ossimXmlNode.cpp
@@ -467,7 +467,8 @@ const ossimRefPtr<ossimXmlNode>& ossimXmlNode::findFirstNode(const ossimString& 
    ossimXmlNode::ChildListType::const_iterator child_iter = theChildNodes.begin();
    ossimXmlNode::ChildListType::const_iterator child_end  = theChildNodes.end();
 
-   if (delim_pos==std::string::npos) // No XPATH_DELIM character found
+   // No XPATH_DELIM character found, or XPATH_DELIM at the end of xpath
+   if (delim_pos==std::string::npos || delim_pos == xpath.size()-1) 
    {
       for ( ; child_iter != child_end ; ++ child_iter)
       {
@@ -535,7 +536,8 @@ ossimRefPtr<ossimXmlNode> ossimXmlNode::findFirstNode(const ossimString& xpath)
    ossimXmlNode::ChildListType::iterator child_iter = theChildNodes.begin();
    ossimXmlNode::ChildListType::iterator child_end  = theChildNodes.end();
 
-   if (delim_pos==std::string::npos) // No XPATH_DELIM character found
+   // No XPATH_DELIM character found, or XPATH_DELIM at the end of xpath
+   if (delim_pos==std::string::npos || delim_pos == xpath.size()-1) 
    {
       for ( ; child_iter != child_end ; ++ child_iter)
       {
@@ -814,7 +816,8 @@ ossimRefPtr<ossimXmlNode> ossimXmlNode::addNode(const ossimString& relPath,
    
    if(!node.valid())
    {
-      if (delim_pos==std::string::npos) // No XPATH_DELIM character found
+      // No XPATH_DELIM character found, or XPATH_DELIM at the end of xpath
+      if (delim_pos==std::string::npos || delim_pos == relPath.size()-1) 
       {
          node = addChildNode(desiredTag, text);
       }
@@ -823,7 +826,7 @@ ossimRefPtr<ossimXmlNode> ossimXmlNode::addNode(const ossimString& relPath,
          node = addChildNode(desiredTag, "");
       }
    }
-   if (delim_pos != std::string::npos) // XPATH_DELIM character found!
+   if (delim_pos != std::string::npos && delim_pos != relPath.size()-1) // XPATH_DELIM character found!
    {
       const ossimString subPath   = relPath.substr(delim_pos+1, std::string::npos);
       return node->addNode(subPath, text);


### PR DESCRIPTION
Cases where the xpath ends with a trailing slash are not correctly handled.