### PR TITLE
Remove "Conditional jump or move depends on uninitialised value(s)"

### DIFF
--- a/src/projection/ossimSensorModelFactory.cpp
+++ b/src/projection/ossimSensorModelFactory.cpp
@@ -364,11 +364,10 @@ ossimProjection* ossimSensorModelFactory::createProjection(
    }
    
    ifstream input(geomFile.c_str());
-   char ecgTest[4];
-   input.read((char*)ecgTest, 3);
-   ecgTest[3] = '\0';
+   char ecgTest[4] = { 0 };
+   input.read(ecgTest, 3); // even if `read()` fails, it will be initialized thanks to `= { 0 };`
    input.close();
-   if(ossimString(ecgTest) == "eCG")
+   if(std::string(ecgTest) == "eCG")
    {
       ossimKeywordlist kwlTemp;
       kwlTemp.add("type",


### PR DESCRIPTION
If the file cannot be read, the character buffer won't be changed. As a
consequence, we could just let it be filled (unconditionally) with zeros. We
don't need to test whether `read()` has succeeded.