### PR TITLE
Simplify code

### DIFF
--- a/include/ossim/base/ossimColumnVector3d.h
+++ b/include/ossim/base/ossimColumnVector3d.h
@@ -39,12 +39,8 @@ public:
          data[2]=z;
       }
 
-   ossimColumnVector3d(const ossimColumnVector3d &rhs)
-   {
-      data[0] = rhs.data[0];
-      data[1] = rhs.data[1];
-      data[2] = rhs.data[2];
-   }
+   // Default copy-constructor is perfect
+   // ossimColumnVector3d(const ossimColumnVector3d &rhs) = default;
    
    explicit ossimColumnVector3d(const NEWMAT::ColumnVector& rhs)
    {

--- a/include/ossim/base/ossimEcefPoint.h
+++ b/include/ossim/base/ossimEcefPoint.h
@@ -41,8 +41,8 @@ public:
    ossimEcefPoint()
       : theData(0,0,0) {}
 
-   ossimEcefPoint(const ossimEcefPoint& copy_this)
-      : theData (copy_this.theData) {}
+   // Default definition is perfect
+   // ossimEcefPoint(const ossimEcefPoint& copy_this) = default;
 
    ossimEcefPoint(const ossimGpt& convert_this);
 
@@ -87,7 +87,7 @@ public:
    ossimEcefVector       operator- (const ossimEcefPoint&)  const;
    ossimEcefPoint        operator+ (const ossimEcefVector&) const;
    ossimEcefPoint        operator- (const ossimEcefVector&) const;
-   const ossimEcefPoint& operator= (const ossimEcefPoint&);        // inline
+   // ossimEcefPoint&       operator= (const ossimEcefPoint&) = default;
    bool                  operator==(const ossimEcefPoint&)  const; // inline
    bool                  operator!=(const ossimEcefPoint&)  const; // inline
    
@@ -190,16 +190,6 @@ protected:
 };
 
 //================== BEGIN DEFINITIONS FOR INLINE METHODS =====================
-
-//*****************************************************************************
-//  INLINE METHOD: ossimEcefPoint::operator=(ossimEcefPoint)
-//*****************************************************************************
-inline const ossimEcefPoint&
-ossimEcefPoint::operator=(const ossimEcefPoint& p)
-{
-   theData = p.theData;
-   return *this;
-}
 
 //*****************************************************************************
 //  INLINE METHOD: ossimEcefPoint::operator==(ossimEcefPoint)


### PR DESCRIPTION
No need to define copy-constructors and assignement operators when they are
just copying all attributes. We'd better let the compiler do its job. It'll
be more efficient that us and less error prone.