### PR TITLE
Histogram computation to use almostEqual() for null check on floating point values

### DIFF
--- a/include/ossim/support_data/ossimInfoBase.h
+++ b/include/ossim/support_data/ossimInfoBase.h
@@ -11,12 +11,11 @@
 //----------------------------------------------------------------------------
 // $Id$
 #ifndef ossimInfoBase_HEADER
-#define ossimInfoBase_HEADER
-
-#include <iosfwd>
+#define ossimInfoBase_HEADER 1
 
 #include <ossim/base/ossimConstants.h>
 #include <ossim/base/ossimReferenced.h>
+#include <iosfwd>
 
 class ossimFilename;
 class ossimKeywordlist;
@@ -71,6 +70,16 @@ public:
     * @return true on success, false on error.
     */
    virtual bool getKeywordlist(ossimKeywordlist& kwl)const;
+
+   /**
+    * @brief Method to dump info to a keyword list.
+    * @param kwl The keyword list to initialize.
+    * @param entryIndex Entry to print.  Not supported by all info objects
+    * yet.
+    * @return true on success, false on error.
+    */
+   virtual bool getKeywordlist(ossimKeywordlist& kwl,
+                               ossim_uint32 entryIndex)const;
 
 protected:
    /** virtual destructor */

--- a/include/ossim/support_data/ossimNitfFile.h
+++ b/include/ossim/support_data/ossimNitfFile.h
@@ -11,7 +11,7 @@
 //********************************************************************
 // $Id: ossimNitfFile.h 19583 2011-05-13 10:58:10Z gpotts $
 #ifndef ossimNitfFile_HEADER
-#define ossimNitfFile_HEADER
+#define ossimNitfFile_HEADER 1
 
 #include <iosfwd>
 #include <vector>
@@ -50,6 +50,23 @@ public:
     * @return output stream.
     */
    std::ostream& print(std::ostream& out,
+                       const std::string& prefix=std::string(),
+                       bool printOverviews=false) const;
+
+   /**
+    * @brief print method that outputs a key/value type format adding prefix
+    * to keys.
+    * @param out Stream to output to.
+    * @param entryIndex Entry to print.  Not supported by all info objects
+    * @param prefix This will be prepended to key.
+    * e.g. Where prefix = "nitf." and key is "file_name" key becomes:
+    * "nitf.file_name:"
+    * @param printOverviews If true overview, if present(e.g. rpf's) will be 
+    * printed.
+    * @return output stream.
+    */
+   std::ostream& print(std::ostream& out,
+                       ossim_uint32 entryIndex, 
                        const std::string& prefix=std::string(),
                        bool printOverviews=false) const;
    

--- a/include/ossim/support_data/ossimNitfInfo.h
+++ b/include/ossim/support_data/ossimNitfInfo.h
@@ -49,8 +49,6 @@ public:
     * @return std::ostream&
     */
    virtual std::ostream& print(std::ostream& out) const;
-
-   virtual bool getKeywordlist(ossimKeywordlist& kwl)const;
    
 private:
    ossimRefPtr<ossimNitfFile> m_nitfFile;

--- a/include/ossim/support_data/ossimNitfInfo.h
+++ b/include/ossim/support_data/ossimNitfInfo.h
@@ -9,13 +9,13 @@
 //----------------------------------------------------------------------------
 // $Id$
 #ifndef ossimNitfInfo_HEADER
-#define ossimNitfInfo_HEADER
+#define ossimNitfInfo_HEADER 1
 
-#include <iosfwd>
 #include <ossim/base/ossimConstants.h>
 #include <ossim/base/ossimRefPtr.h>
 #include <ossim/support_data/ossimInfoBase.h>
 #include <ossim/support_data/ossimNitfFile.h>
+#include <iosfwd>
 
 /**
  * @brief NITF info class.
@@ -49,6 +49,16 @@ public:
     * @return std::ostream&
     */
    virtual std::ostream& print(std::ostream& out) const;
+
+   /**
+    * @brief Method to dump info to a keyword list.
+    * @param kwl The keyword list to initialize.
+    * @param entryIndex Entry to print.  Not supported by all info objects
+    * yet.
+    * @return true on success, false on error.
+    */
+   virtual bool getKeywordlist( ossimKeywordlist& kwl,
+                                ossim_uint32 entryIndex )const;
    
 private:
    ossimRefPtr<ossimNitfFile> m_nitfFile;

--- a/include/ossim/support_data/ossimQuickbirdMetaData.h
+++ b/include/ossim/support_data/ossimQuickbirdMetaData.h
@@ -102,6 +102,9 @@ public:
 
    const ossimIpt& getImageSize() const;
 
+   bool getMapProjectionKwl( const ossimFilename& imd_file,
+                             ossimKeywordlist& kwl );
+
 /*****************************************
 *parseATTData EPH GEO IMD RPB TIL
 *

--- a/include/ossim/support_data/ossimRpfToc.h
+++ b/include/ossim/support_data/ossimRpfToc.h
@@ -9,10 +9,7 @@
 //*************************************************************************
 // $Id: ossimRpfToc.h 18044 2010-09-06 14:20:52Z dburken $
 #ifndef osimRpfToc_HEADER
-#define osimRpfToc_HEADER
-
-#include <vector>
-#include <iosfwd>
+#define osimRpfToc_HEADER 1
 
 #include <ossim/base/ossimConstants.h>
 #include <ossim/base/ossimErrorCodes.h>
@@ -22,6 +19,9 @@
 #include <ossim/base/ossimRefPtr.h>
 #include <ossim/support_data/ossimNitfFileHeader.h>
 #include <ossim/support_data/ossimRpfHeader.h>
+
+#include <vector>
+#include <iosfwd>
 
 class ossimRpfFrameFileIndexSubsection;
 class ossimRpfTocEntry;
@@ -64,13 +64,46 @@ public:
     * to keys.
     * @param out String to output to.
     * @param prefix This will be prepended to key.
-    * e.g. Where prefix = "nitf." and key is "file_name" key becomes:
-    * "nitf.file_name:"
+    * e.g. Where prefix = "nitf.rpf." and key is "file_name" key becomes:
+    * "nitf.rpm.file_name:"
     * @return output stream.
     */
-   std::ostream& print(std::ostream& out,
-                       const std::string& prefix=std::string(),
-                       bool printOverviews=false) const;
+   std::ostream& print( std::ostream& out,
+                        const std::string& prefix=std::string(),
+                        bool printOverviews=false ) const;
+   
+   /**
+    * @brief print method that outputs a key/value type format adding prefix
+    * to keys.
+    *
+    * This prints the rpf header part only.
+    * 
+    * @param out String to output to.
+    * @param prefix This will be prepended to key.
+    * e.g. Where prefix = "nitf.rpf." and key is "file_name" key becomes:
+    * "nitf.rpf.file_name:"
+    * @return output stream.
+    */   
+   std::ostream& printHeader( std::ostream& out,
+                              const std::string& prefix=std::string() ) const;
+
+   /**
+    * @brief print method that outputs a key/value type format adding prefix
+    * to keys.
+    *
+    * This prints the specific rpf toc entry.
+    * 
+    * @param out String to output to.
+    * @param prefix This will be prepended to key.
+    * e.g. Where prefix = "nitf.rpf." and key is "file_name" key becomes:
+    * "nitf.rpf.file_name:"
+    * @return output stream.
+    */   
+   std::ostream& printTocEntry( std::ostream& out,
+                                ossim_uint32 entryIndex,
+                                const std::string& prefix=std::string(),
+                                bool printOverviews=false ) const;
+   
    
    ossim_uint32 getNumberOfEntries()const;
    

--- a/include/ossim/util/ossimImageUtil.h
+++ b/include/ossim/util/ossimImageUtil.h
@@ -177,6 +177,13 @@ public:
    void setTileSize( ossim_uint32 tileSize );
 
    /**
+    * @brief Gets the tile size.
+    * @param tileSize Initialized by this.
+    * @return true on success, false if not in options list.
+    */
+   bool getTileSize( ossimIpt& tileSize ) const;
+
+   /**
     * @return Overview stop dimension or 0 if OVERVIEW_STOP_DIM_KW is not
     * found.
     */

--- a/src/imaging/ossimImageHandler.cpp
+++ b/src/imaging/ossimImageHandler.cpp
@@ -897,10 +897,33 @@ bool ossimImageHandler::openOverview()
       {  
          // 3) For backward compatibility check if single entry and _e0.ovr
          overviewFilename = getFilenameWithThisExtension(ossimString(".ovr"), true);
+
          if (overviewFilename.empty() || (overviewFilename.exists() == false) )
          {
-            // 4) For overviews built with gdal look for foo.tif.ovr
-            overviewFilename = getFilename();
+            //---
+            // 4) For overviews built with gdal.
+            // Examples:
+            // Single entry: foo.tif.ovr
+            // Multi-entry: foo.tif.x.ovr where "x" == one based entry number.
+            // 
+            // Note: Take into account a supplementary dir if any.
+            //---
+            if ( theSupplementaryDirectory.empty() )
+            {
+               overviewFilename = getFilename();
+            }
+            else
+            {
+               overviewFilename = theSupplementaryDirectory;
+               overviewFilename = overviewFilename.dirCat( getFilename().file() );
+            }
+
+            if ( getNumberOfEntries() > 1 )
+            {
+               overviewFilename += ".";
+               // Sample multi-entry data "one" based; hence, the + 1.
+               overviewFilename += ossimString::toString( getCurrentEntry()+1 );
+            }
             overviewFilename += ".ovr";
          }
       }

--- a/src/imaging/ossimQbTileFilesHandler.cpp
+++ b/src/imaging/ossimQbTileFilesHandler.cpp
@@ -24,8 +24,10 @@
 #include <ossim/base/ossimTrace.h>
 #include <ossim/imaging/ossimImageGeometry.h>
 #include <ossim/imaging/ossimImageHandlerRegistry.h>
+#include <ossim/projection/ossimProjectionFactoryRegistry.h>
 #include <ossim/imaging/ossimTiffOverviewBuilder.h>
 #include <ossim/imaging/ossimTiffTileSource.h>
+#include <ossim/support_data/ossimQuickbirdMetaData.h>
 #include <ossim/support_data/ossimQuickbirdTile.h>
 #include <ossim/projection/ossimQuickbirdRpcModel.h>
 #include <algorithm>
@@ -182,24 +184,53 @@ bool ossimQbTileFilesHandler::open()
 //*************************************************************************************************
 ossimRefPtr<ossimImageGeometry> ossimQbTileFilesHandler::getImageGeometry()
 {
-   // Try external geom first:
-   theGeometry = getExternalImageGeometry();
-   if (theGeometry.valid())
-      return theGeometry;  // We should return here.
-   
-   // The dataset is expected to have an RPC model associated with it:
-   ossimRefPtr<ossimQuickbirdRpcModel> model = new ossimQuickbirdRpcModel(this);
-   if (!model->getErrorStatus())
+   if ( !theGeometry )
    {
-      theGeometry = new ossimImageGeometry;
-      theGeometry->setProjection(model.get());
+      // Try external geom first:
+      theGeometry = getExternalImageGeometry();
       
+      if ( !theGeometry )
+      {
+         theGeometry = new ossimImageGeometry;
+         
+         // The dataset is expected to have an RPC model associated with it:
+         ossimRefPtr<ossimQuickbirdRpcModel> model = new ossimQuickbirdRpcModel(this);
+         if (!model->getErrorStatus())
+         {
+            theGeometry->setProjection(model.get());
+         }
+         else
+         {
+            // Check for map projected data:
+            ossimFilename imd_file = theImageFile;
+            imd_file.setExtension("IMD");
+            if ( imd_file.exists() == false )
+            {
+               imd_file.setExtension("imd");
+            }
+
+            if ( imd_file.exists() )
+            {
+               ossimQuickbirdMetaData md;
+               ossimKeywordlist kwl;
+               if ( md.getMapProjectionKwl( imd_file, kwl ) == true )
+               {
+                  ossimRefPtr<ossimProjection> proj = ossimProjectionFactoryRegistry::instance()->
+                     createProjection( kwl, 0 );
+                  if ( proj.valid() == true )
+                  {
+                     theGeometry->setProjection( proj.get() );
+                  }
+               }
+            }
+         }
+      }
+            
       // Set image things the geometry object should know about.
       initImageParameters( theGeometry.get() );
-
-      return theGeometry;
    }
-   return ossimRefPtr<ossimImageGeometry>();
+   
+   return theGeometry;
 }
 
 //*************************************************************************************************

--- a/src/imaging/ossimQuickbirdTiffTileSource.cpp
+++ b/src/imaging/ossimQuickbirdTiffTileSource.cpp
@@ -102,24 +102,6 @@ ossimRefPtr<ossimImageGeometry> ossimQuickbirdTiffTileSource::getImageGeometry()
 
                if ( infoStatus )
                {
-                  // Establish sub-image offset (shift) for this tile:
-                  ossimDpt shift(0,0);
-                  if ((info.theUlXOffset != OSSIM_INT_NAN) && (info.theUlYOffset != OSSIM_INT_NAN))
-                     shift = ossimIpt(info.theUlXOffset, info.theUlYOffset);
-                  
-                  if(traceDebug())
-                  {
-                     ossimNotify(ossimNotifyLevel_DEBUG)
-                        << "ossimQuickbirdTiffTileSource::open() DEBUG:"
-                        << "\nSub image offset  = " << shift << std::endl;
-                  }
-
-                  // Create the transform and set it in the geometry object:
-                  ossimRefPtr<ossim2dTo2dTransform> transform =
-                     new ossim2dTo2dShiftTransform(shift);
-
-                  theGeometry->setTransform(transform.get());
-   
                   // Next is the projection part of the image geometry. This should be available
                   // as an external RPC file or internal RPC's in the tiff file. Otherwise use
                   // the map projection specified in the 
@@ -129,6 +111,27 @@ ossimRefPtr<ossimImageGeometry> ossimQuickbirdTiffTileSource::getImageGeometry()
                   ossimRefPtr<ossimQuickbirdRpcModel> model = new ossimQuickbirdRpcModel;
                   if (model->parseFile(theImageFile))
                   {
+                     //---
+                     // If RPC projection set the sub-image offset:
+                     // Establish sub-image offset (shift) for this tile:
+                     //---
+                     ossimDpt shift(0,0);
+                     if ((info.theUlXOffset != OSSIM_INT_NAN) &&
+                         (info.theUlYOffset != OSSIM_INT_NAN))
+                        shift = ossimIpt(info.theUlXOffset, info.theUlYOffset);
+                     
+                     if(traceDebug())
+                     {
+                        ossimNotify(ossimNotifyLevel_DEBUG)
+                           << "ossimQuickbirdTiffTileSource::open() DEBUG:"
+                           << "\nSub image offset  = " << shift << std::endl;
+                     }
+
+                     // Create the transform and set it in the geometry object:
+                     ossimRefPtr<ossim2dTo2dTransform> transform =
+                        new ossim2dTo2dShiftTransform(shift);
+                     
+                     theGeometry->setTransform(transform.get());
                      theGeometry->setProjection(model.get());
                   }
                   else

--- a/src/imaging/ossimTiledImageHandler.cpp
+++ b/src/imaging/ossimTiledImageHandler.cpp
@@ -137,17 +137,18 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
    // Loop over all tile-files to find which intersect the requested image rect. This necessarily
    // needs to be done at full res coordinates, so need to adjust by res level requested:
    ossimDpt decimation_factor;
-   const ossim_uint32 BANDS = m_tile->getNumberOfBands();
+   // const ossim_uint32 BANDS = m_tile->getNumberOfBands();
    // const ossim_uint32 PPB   = m_tile->getSizePerBand(); // pixels per band
    // bool none_found = true;
 
    m_tile->setImageRectangle(tile_rect);
-   ossim_uint32 wd, hd, ws, hs;
-   m_tile->getWidthHeight(wd, hd);
+   
+   // ossim_uint32 wd, hd, ws, hs;
+   // m_tile->getWidthHeight(wd, hd);
 
    // Always start with blank tile.
    m_tile->makeBlank();
-   
+
    // See if any point of the requested tile is in the image.
    if ( tile_rect.intersects( m_fullImgRect ) )
    {
@@ -158,9 +159,44 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
          if (( (*tf_iter).subImageRects.size() > resLevel) &&
              tile_rect.intersects((*tf_iter).subImageRects[resLevel]))
          {
-            // Current image handler lies within requested rect, need to adjust this rect to be 
-            // relative to this subimage offset before fetching the tile:
+            //---
+            // Current image handler lies within requested rect, need to adjust
+            // this rect to be relative to this subimage offset before fetching
+            // the tile:
+            //---
+            ossimIrect full_image_clip_rect =
+               tile_rect.clipToRect( (*tf_iter).subImageRects[resLevel]);
+
+            // Subtract the sub image offset to make zero base image rect.
+            ossimIrect relative_clip_rect( full_image_clip_rect -
+                                           (*tf_iter).subImageRects[resLevel].ul());
+            
+            source_tile = (*tf_iter).imageHandler->getTile(relative_clip_rect, resLevel);
+            if ( source_tile.valid() )
+            {
+               // Give the loadTile the clip rect relative to the full image.
+               m_tile->loadTile( source_tile->getBuf(),
+                                 full_image_clip_rect,
+                                 OSSIM_BSQ);
+               m_tile->validate();
+               if ( m_tile->getDataObjectStatus() == OSSIM_FULL )
+               {
+                  break;
+               }
+            }
+         }
+         ++tf_iter;
+      }
+      
+   } // Matches: if ( tile_rect.intersects( m_fullImgRect ) )
+   return m_tile;
+}
+
+// Below code was core dumping on tiled DG data. drb - 20160822
+#if 0 
+   
             ossimIrect relative_rect (tile_rect - (*tf_iter).subImageRects[resLevel].ul());
+            std::cout << "reletive_rect: " << relative_rect << std::endl;
             source_tile = (*tf_iter).imageHandler->getTile(relative_rect, resLevel);
             
             // Quick check to see if a full tile was returned, in which case we can just return that
@@ -173,6 +209,8 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
 
             // Set the tile's rect back to full image space before saving to the list:
             source_tile->getWidthHeight(ws, hs);
+            std::cout << "ws: " << ws << " hs: " << hs << " wd: " << wd << " hd: " << hd
+                      << std::endl;
             for (ossim_uint32 band = 0; band < BANDS; ++band)
             {
                const ossim_uint16 null_pixel = (ossim_uint16) m_tile->getNullPix(band);
@@ -180,12 +218,13 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
                ossim_uint16* d = (ossim_uint16*) m_tile->getBuf(band);
                ossim_uint32 is = 0; 
                ossim_uint32 id = 0; 
-               for (ossim_uint32 y=0; (y<hd)&&(y<hs); y++)
+               for (ossim_uint32 y=0; (y<hd)&&(y<hs); ++y)
                {
-                  for (ossim_uint32 x=0; x<wd; x++)
+                  for (ossim_uint32 x=0; x<wd; ++x)
                   {
                      if (x < ws)
                      {
+                        // cout << "is: " << is << endl;
                         if (s[is] != null_pixel)
                            d[id] = s[is];
                         ++is;
@@ -194,6 +233,8 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
                   }
                }
             }
+
+
          }
          ++tf_iter;
       }
@@ -204,6 +245,7 @@ ossimRefPtr<ossimImageData> ossimTiledImageHandler::getTile(const ossimIrect& ti
 
    return m_tile;
 }
+#endif
 
 //*************************************************************************************************
 //! @param resLevel Reduced resolution level to return lines of.

--- a/src/support_data/ossimInfoBase.cpp
+++ b/src/support_data/ossimInfoBase.cpp
@@ -42,3 +42,10 @@ bool ossimInfoBase::getKeywordlist(ossimKeywordlist& kwl)const
    // Give the result to the keyword list.
    return kwl.parseStream(in);
 }
+
+bool ossimInfoBase::getKeywordlist(ossimKeywordlist& kwl,
+                                   ossim_uint32 /* entryIndex */ )const
+{
+   // If this gets hit the specific info object does not support entry indexes.
+   return getKeywordlist( kwl );
+}

--- a/src/support_data/ossimNitfInfo.cpp
+++ b/src/support_data/ossimNitfInfo.cpp
@@ -9,9 +9,12 @@
 //----------------------------------------------------------------------------
 // $Id$
 
-#include <iostream>
+
 
 #include <ossim/support_data/ossimNitfInfo.h>
+#include <ossim/base/ossimKeywordlist.h>
+#include <ostream>
+#include <sstream>
 
 ossimNitfInfo::ossimNitfInfo()
    : m_nitfFile(0)
@@ -45,4 +48,18 @@ std::ostream& ossimNitfInfo::print(std::ostream& out) const
       m_nitfFile->print(out, prefix, getProcessOverviewFlag());
    }
    return out;
+}
+
+
+bool ossimNitfInfo::getKeywordlist(ossimKeywordlist& kwl,
+                                   ossim_uint32 entryIndex)const
+{
+   // Do a print to a memory stream.
+   std::ostringstream out;
+   m_nitfFile->print( out, entryIndex );
+
+   std::istringstream in( out.str() );
+
+   // Give the result to the keyword list.
+   return kwl.parseStream( in );
 }

--- a/src/support_data/ossimNitfInfo.cpp
+++ b/src/support_data/ossimNitfInfo.cpp
@@ -46,14 +46,3 @@ std::ostream& ossimNitfInfo::print(std::ostream& out) const
    }
    return out;
 }
-
-bool ossimNitfInfo::getKeywordlist(ossimKeywordlist& kwl)const
-{
-   bool result = false;
-   if ( m_nitfFile.valid() )
-   {
-      m_nitfFile->saveState(kwl, "nitf.");
-   }
-   
-   return result;
-}

--- a/test/src/imaging/CMakeLists.txt
+++ b/test/src/imaging/CMakeLists.txt
@@ -9,6 +9,7 @@ OSSIM_SETUP_APPLICATION(ossim-image-chain-test INSTALL COMMAND_LINE COMPONENT_NA
 OSSIM_SETUP_APPLICATION(ossim-image-handler-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-image-handler-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-image-writer-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-image-writer-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-index-to-rgb-lut-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-index-to-rgb-lut-test.cpp)
+OSSIM_SETUP_APPLICATION(ossim-histogram-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-histogram-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-loadtile-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-loadtile-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-mask-filter-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-mask-filter-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-piecewise-remapper-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-piecewise-remapper-test.cpp)

--- a/test/src/imaging/ossim-histogram-test.cpp
+++ b/test/src/imaging/ossim-histogram-test.cpp
@@ -55,11 +55,19 @@ int main(int argc, char *argv[])
                         ossimRefPtr<ossimHistogram> h = mbh->getHistogram(band);
                         if ( h.valid() )
                         {
-                           cout << "min[" << band << "]: "
-                                << std::floor( h->LowClipVal(0.0) ) << "\n";
-                           cout << "max[" << band << "]: "
-                                << std::floor(h->HighClipVal(0.0)) << "\n";
-                        }
+                           cout << "band:            " << band << "\n"
+                                << "min_val:         " << h->GetMinVal() << "\n"
+                                << "max_val:         " << h->GetMaxVal() << "\n"
+                                << "max_count:       " << h->GetMaxCount() << "\n"
+                                << "vmin:            " << h->GetRangeMin() << "\n"
+                                << "vmax:            " << h->GetRangeMax() << "\n"
+                                << "low_clip(0%):    " << std::floor( h->LowClipVal(0.0) ) << "\n"
+                                << "high_clip(0%):   " << std::floor( h->HighClipVal(0.0) ) << "\n"
+                                << "low_clip(0.1%):  " << std::floor( h->LowClipVal(0.001) ) << "\n"
+                                << "high_clip(0.1%): " << std::floor( h->HighClipVal(0.001) ) << "\n"
+                                << "low_clip(1%):    " << std::floor( h->LowClipVal(0.01) ) << "\n"
+                                << "high_clip(1%):   " << std::floor( h->HighClipVal(0.01) ) << "\n\n";
+                       }
                      }
                      cout << endl;
                   }

--- a/test/src/imaging/ossim-histogram-test.cpp
+++ b/test/src/imaging/ossim-histogram-test.cpp
@@ -1,0 +1,97 @@
+//---
+// License: MIT
+//
+// File: ossim-quickbird-metadata-test.cpp
+//
+// Description: Test code for ossim histogram stuff.
+//---
+// $Id$
+
+#include <ossim/base/ossimException.h>
+#include <ossim/base/ossimHistogram.h>
+#include <ossim/base/ossimKeywordlist.h>
+#include <ossim/base/ossimMultiResLevelHistogram.h>
+#include <ossim/base/ossimMultiBandHistogram.h>
+#include <ossim/base/ossimNotify.h>
+#include <ossim/base/ossimRefPtr.h>
+#include <ossim/init/ossimInit.h>
+#include <cmath>
+#include <iostream>
+
+using namespace std;
+
+static void usage()
+{
+   cout << "ossim-histogram-test <ossim_histogram_file>" << endl;
+}
+
+int main(int argc, char *argv[])
+{
+   int returnCode = 0;
+
+   ossimInit::instance()->initialize(argc, argv);
+
+   if (argc == 2)
+   {
+      try
+      {
+         ossimFilename file = argv[argc - 1];
+         if ( file.exists() )
+         {
+            ossimRefPtr<ossimMultiResLevelHistogram> mrh = new ossimMultiResLevelHistogram();
+            if ( mrh.valid() )
+            {
+               if ( mrh->importHistogram(file) == true )
+               {
+                  cout << "opened histogram: " << file << "\n";
+                  
+                  ossimRefPtr<ossimMultiBandHistogram> mbh = mrh->getMultiBandHistogram(0);
+                  if ( mbh.valid() )
+                  {
+                     const ossim_uint32 BANDS = mbh->getNumberOfBands();
+                     cout << "bands: " << BANDS << "\n";
+                     for ( ossim_uint32 band = 0; band < BANDS; ++band)
+                     {
+                        ossimRefPtr<ossimHistogram> h = mbh->getHistogram(band);
+                        if ( h.valid() )
+                        {
+                           cout << "min[" << band << "]: "
+                                << std::floor( h->LowClipVal(0.0) ) << "\n";
+                           cout << "max[" << band << "]: "
+                                << std::floor(h->HighClipVal(0.0)) << "\n";
+                        }
+                     }
+                     cout << endl;
+                  }
+               }
+            }
+            else
+            {
+               cout << "could not open: " << file << endl;
+            }
+         }
+         else
+         {
+            usage();
+            returnCode = 1;
+         }
+      }
+      catch(const ossimException& e)
+      {
+         ossimNotify(ossimNotifyLevel_WARN) << e.what() << std::endl;
+         returnCode = 1;
+      }
+      catch( ... )
+      {
+         ossimNotify(ossimNotifyLevel_WARN)
+            << "ossim-foo caught unhandled exception!" << std::endl;
+         returnCode = 1;
+      }
+   }
+   else
+   {
+      usage();
+   }
+   
+   return returnCode;
+}

--- a/test/src/imaging/ossim-histogram-test.cpp
+++ b/test/src/imaging/ossim-histogram-test.cpp
@@ -55,10 +55,15 @@ int main(int argc, char *argv[])
                         ossimRefPtr<ossimHistogram> h = mbh->getHistogram(band);
                         if ( h.valid() )
                         {
+                           ossim_uint32 min_idx = std::floor(h->GetMinVal());
+                           ossim_uint32 max_idx = std::floor(h->GetMaxVal());
+                           
                            cout << "band:            " << band << "\n"
                                 << "min_val:         " << h->GetMinVal() << "\n"
                                 << "max_val:         " << h->GetMaxVal() << "\n"
                                 << "max_count:       " << h->GetMaxCount() << "\n"
+                                << "min_val_count:   " << h->GetCounts()[min_idx] << "\n"
+                                << "max_val_count:   " << h->GetCounts()[max_idx]  << "\n"
                                 << "vmin:            " << h->GetRangeMin() << "\n"
                                 << "vmax:            " << h->GetRangeMax() << "\n"
                                 << "low_clip(0%):    " << std::floor( h->LowClipVal(0.0) ) << "\n"

--- a/test/src/support_data/CMakeLists.txt
+++ b/test/src/support_data/CMakeLists.txt
@@ -3,6 +3,7 @@
 OSSIM_SETUP_APPLICATION(ossim-aux-dot-xml-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-aux-dot-xml-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-envi-hdr-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-envi-hdr-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-fgdc-txt-doc-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-fgdc-txt-doc-test.cpp)
+OSSIM_SETUP_APPLICATION(ossim-quickbird-metadata-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-quickbird-metadata-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-srtm-support-data-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-srtm-support-data-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-tiff-info-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-tiff-info-test.cpp)
 OSSIM_SETUP_APPLICATION(ossim-wavelength-test INSTALL COMMAND_LINE COMPONENT_NAME ossim SOURCE_FILES ossim-wavelength-test.cpp)

--- a/test/src/support_data/ossim-quickbird-metadata-test.cpp
+++ b/test/src/support_data/ossim-quickbird-metadata-test.cpp
@@ -1,0 +1,73 @@
+//---
+// License: MIT
+//
+// File: ossim-quickbird-metadata-test.cpp
+//
+// Description: Test code for Quickbird/Digital Globe dot.IMD file.
+//---
+// $Id$
+
+#include <ossim/base/ossimException.h>
+#include <ossim/base/ossimKeywordlist.h>
+#include <ossim/base/ossimNotify.h>
+#include <ossim/init/ossimInit.h>
+#include <ossim/support_data/ossimQuickbirdMetaData.h>
+#include <iostream>
+
+using namespace std;
+
+static void usage()
+{
+   cout << "ossim-quickbird-metadata-test <IMD_file>" << endl;
+}
+
+int main(int argc, char *argv[])
+{
+   int returnCode = 0;
+
+   ossimInit::instance()->initialize(argc, argv);
+
+   if (argc == 2)
+   {
+      try
+      {
+         ossimFilename file = argv[argc - 1];
+         if ( file.exists() )
+         {
+            ossimQuickbirdMetaData md;
+            if ( md.open( file ) )
+            {
+               md.print( cout );
+            }
+
+            ossimKeywordlist kwl;
+            if ( md.getMapProjectionKwl( file, kwl ) == true )
+            {
+               cout << "kwl:\n" << kwl << endl;
+            }
+         }
+         else
+         {
+            usage();
+            returnCode = 1;
+         }
+      }
+      catch(const ossimException& e)
+      {
+         ossimNotify(ossimNotifyLevel_WARN) << e.what() << std::endl;
+         returnCode = 1;
+      }
+      catch( ... )
+      {
+         ossimNotify(ossimNotifyLevel_WARN)
+            << "ossim-foo caught unhandled exception!" << std::endl;
+         returnCode = 1;
+      }
+   }
+   else
+   {
+      usage();
+   }
+   
+   return returnCode;
+}

--- a/test/src/util/ossim-info-test.cpp
+++ b/test/src/util/ossim-info-test.cpp
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
             info->setProcessOverviewFlag(false);
 
             ossimKeywordlist kwl;
+            // if ( info->getKeywordlist( kwl, 9 ) )
             if ( info->getKeywordlist( kwl ) )
             {
                cout << kwl << endl;
@@ -74,7 +75,7 @@ int main(int argc, char *argv[])
          {
             ossimNotify(ossimNotifyLevel_INFO)
                << "No dump available for:  " << file.c_str() << std::endl;
-         }
+         } 
       }
       catch (const ossimException& e)
       {

--- a/test/src/util/ossim-info-test.cpp
+++ b/test/src/util/ossim-info-test.cpp
@@ -18,6 +18,8 @@
 #include <ossim/base/ossimNotify.h>
 #include <ossim/base/ossimRefPtr.h>
 #include <ossim/init/ossimInit.h>
+#include <ossim/support_data/ossimInfoBase.h>
+#include <ossim/support_data/ossimInfoFactoryRegistry.h>
 #include <ossim/util/ossimInfo.h>
 
 #include <iostream>
@@ -43,6 +45,7 @@ int main(int argc, char *argv[])
          // Test the ossimInfo::getImageInfo method.
          ossimRefPtr<ossimInfo> oi = new ossimInfo;
          ossimFilename file(argv[1]);
+
          ossimKeywordlist kwl;
          oi->getImageInfo(file,
                           true,  // dump
@@ -53,6 +56,25 @@ int main(int argc, char *argv[])
                           true,  // palette
                           kwl);
          cout << kwl << endl;
+
+         cout << "\n\ntest info dump to a keyword list:\n";
+         ossimRefPtr<ossimInfoBase> info = ossimInfoFactoryRegistry::instance()->create(file);
+         if (info.valid())
+         {
+            info->setProcessOverviewFlag(false);
+
+            ossimKeywordlist kwl;
+            if ( info->getKeywordlist( kwl ) )
+            {
+               cout << kwl << endl;
+            }
+            info = 0;
+         }
+         else
+         {
+            ossimNotify(ossimNotifyLevel_INFO)
+               << "No dump available for:  " << file.c_str() << std::endl;
+         }
       }
       catch (const ossimException& e)
       {


### PR DESCRIPTION
This is to solve numerical noise problems for strange null pixel values as occurs in VIIRS.