### PR TITLE
Viirs

### DIFF
--- a/include/ossim/base/ossimCommon.h
+++ b/include/ossim/base/ossimCommon.h
@@ -50,9 +50,9 @@ namespace ossim
 /*     inline bool almostEqual(T x, T y, T tolerence = std::numeric_limits<T>::epsilon()) */
 /*         // are x and y within tolerance distance of each other? */
 /*         { return std::abs(x - y) <= tolerence; } */
-    inline bool almostEqual(T x, T y, T tolerence = FLT_EPSILON)
+    inline bool almostEqual(T x, T y, T tolerance = FLT_EPSILON)
         // are x and y within tolerance distance of each other?
-        { return std::fabs(x - y) <= tolerence; }
+        { return std::fabs(x - y) <= tolerance; }
 
     template <class T>
     inline bool inInterval(T x, T a, T b)

--- a/include/ossim/hdf5/ossimHdf5GridModel.h
+++ b/include/ossim/hdf5/ossimHdf5GridModel.h
@@ -43,6 +43,9 @@ public:
    /** Initializes from an open HDF5 file */
    bool initialize(ossimHdf5* hdf5, const ossimString& projDataPath="");
 
+   /** Makes sure that the "type" keyword entry reflects the base class, not this one. */
+   virtual bool saveState(ossimKeywordlist& kwl, const char* prefix) const;
+
 protected:
 
    bool initCoarseGrid(const char* datasetName, ossimDblGrid& coarseGrid);

--- a/include/ossim/hdf5/ossimHdf5ImageDataset.h
+++ b/include/ossim/hdf5/ossimHdf5ImageDataset.h
@@ -110,7 +110,7 @@ public:
     *
     *  @param band
     */
-   void getTileBuf(void* buffer, const ossimIrect& rect, ossim_uint32 band);   
+   void getTileBuf(void* buffer, const ossimIrect& rect, ossim_uint32 band, bool scale=true);
 
    /**
     * @brief print method.

--- a/include/ossim/hdf5/ossimViirsHandler.h
+++ b/include/ossim/hdf5/ossimViirsHandler.h
@@ -1,0 +1,32 @@
+/*****************************************************************************
+*                                                                            *
+*                                 O S S I M                                  *
+*            Open Source, Geospatial Image Processing Project                *
+*          License: MIT, see LICENSE at the top-level directory              *
+*                                                                            *
+*****************************************************************************/
+
+#ifndef OSSIM_PLUGINS_HDF5_SRC_OSSIMVIIRSHANDLER_H_
+#define OSSIM_PLUGINS_HDF5_SRC_OSSIMVIIRSHANDLER_H_
+
+#include <ossim/plugin/ossimPluginConstants.h>
+#include <ossim/base/ossimIrect.h>
+#include <ossim/base/ossimRefPtr.h>
+#include <ossim/imaging/ossimImageData.h>
+#include <ossim/hdf5/ossimHdf5ImageHandler.h>
+
+/**
+ * Concrete class for reading VIIRS data from HDF5 file
+ */
+class OSSIM_PLUGINS_DLL ossimViirsHandler : public ossimHdf5ImageHandler
+{
+public:
+   ossimViirsHandler();
+   virtual ossimRefPtr<ossimImageGeometry> getImageGeometry();
+   virtual double getNullPixelValue(ossim_uint32 band=0)const;
+
+};
+
+
+
+#endif /* OSSIM_PLUGINS_HDF5_SRC_OSSIMVIIRSHANDLER_H_ */

--- a/src/hdf5/ossimViirsHandler.cpp
+++ b/src/hdf5/ossimViirsHandler.cpp
@@ -1,0 +1,49 @@
+/*****************************************************************************
+*                                                                            *
+*                                 O S S I M                                  *
+*            Open Source, Geospatial Image Processing Project                *
+*          License: MIT, see LICENSE at the top-level directory              *
+*                                                                            *
+*****************************************************************************/
+
+#include <ossim/hdf5/ossimViirsHandler.h>
+#include <ossim/hdf5/ossimHdf5GridModel.h>
+
+static const ossimString VIIRS_DATASET  ("/All_Data/VIIRS-DNB-SDR_All/Radiance");
+static const ossimString VIIRS_GEOMETRY ("/All_Data/VIIRS-DNB-GEO_All");
+
+ossimViirsHandler::ossimViirsHandler()
+{
+   m_renderableNames.push_back(VIIRS_DATASET);
+}
+
+ossimRefPtr<ossimImageGeometry> ossimViirsHandler::getImageGeometry()
+{
+   if (theGeometry.valid())
+      return theGeometry;
+
+   theGeometry = getExternalImageGeometry();
+   if (!theGeometry.valid() && isOpen())
+   {
+      theGeometry =  new ossimImageGeometry();
+
+      // Attempt to create an OSSIM coarse grid model from HDF5 lat lon grids:
+      ossimRefPtr<ossimHdf5GridModel> hdf5GridModel = new ossimHdf5GridModel;
+      if ( hdf5GridModel->initialize(m_hdf5.get(), VIIRS_GEOMETRY) )
+      {
+         theGeometry->setProjection(hdf5GridModel.get());
+         initImageParameters( theGeometry.get() );
+      }
+      else
+         theGeometry = 0;
+   }
+
+   return theGeometry;
+}
+
+
+double ossimViirsHandler::getNullPixelValue(ossim_uint32 band) const
+{
+   // NPP VIIRS data has null of "-999.3".
+   return -999.3;
+}


### PR DESCRIPTION
After HDF5 refactor, 99.9% of the VIIRS code became common HDF5 code in core, so no need for separate plugin to handle VIIRS since it may just as well be handled entirely in core. Any other unclassified sensors using HDF5 format can be added to core as well.