### PR TITLE
Fixed nitf image header not reading and writing ICOM(image comment). …

### DIFF
--- a/include/ossim/support_data/ossimNitfImageHeaderV2_X.h
+++ b/include/ossim/support_data/ossimNitfImageHeaderV2_X.h
@@ -1,7 +1,8 @@
 #ifndef ossimNitfImageHeaderV2_X_HEADER
-#define ossimNitfImageHeaderV2_X_HEADER
+#define ossimNitfImageHeaderV2_X_HEADER 1
 #include <ossim/base/ossimConstants.h>
 #include <ossim/support_data/ossimNitfImageHeader.h>
+#include <string>
 
 class OSSIM_DLL ossimNitfImageHeaderV2_X : public ossimNitfImageHeader
 {
@@ -382,7 +383,7 @@ protected:
    * FIELD ICOMnn:
    * Dynamic buffer for the comments.  Each comment is 80 bytes
    */
-   char *theImageComments;
+   std::string theImageComments;
 
    /**
     * FIELD: IGEOLO

--- a/src/base/ossimStreamFactory.cpp
+++ b/src/base/ossimStreamFactory.cpp
@@ -60,9 +60,23 @@ std::shared_ptr<ossim::istream> ossim::StreamFactory::createIstream(
 }
       
 std::shared_ptr<ossim::ostream> ossim::StreamFactory::createOstream(
-   const std::string& /*connectionString*/, std::ios_base::openmode /*mode*/) const
+   const std::string& connectionString, std::ios_base::openmode mode) const
 {
-   return std::shared_ptr<ossim::ostream>(0);
+   std::shared_ptr<ossim::ostream> result(0);
+
+   std::shared_ptr<ossim::ofstream> testResult = 
+      std::make_shared<ossim::ofstream>();
+   testResult->open(connectionString.c_str(), mode);
+   if ( testResult->is_open() )
+   {
+      result = testResult;
+   }
+   else
+   {
+      testResult.reset();
+   }
+
+   return result;
 }
 
 std::shared_ptr<ossim::iostream> ossim::StreamFactory::createIOstream(

--- a/src/imaging/ossimWriter.cpp
+++ b/src/imaging/ossimWriter.cpp
@@ -341,7 +341,15 @@ bool ossimWriter::writeTiffTags( const std::vector<ossim_uint64>& tile_offsets,
    tag   = ossim::OTIFFTAG_PHOTOMETRIC;
    type  = ossim::OTIFF_SHORT;
    count = 1;
-   value_ui16 = ossim::OPHOTO_MINISBLACK;
+   if ( theInputConnection->getNumberOfOutputBands() == 3 )
+   {
+      value_ui16 = ossim::OPHOTO_RGB;
+   }
+   else
+   {
+      value_ui16 = ossim::OPHOTO_MINISBLACK;
+   }
+   
    writeTiffTag<ossim_uint16>( tag, type, count, &value_ui16, arrayWritePos );
 
    // samples per pixel tag 277:

--- a/src/support_data/ossimNitfImageHeaderV2_X.cpp
+++ b/src/support_data/ossimNitfImageHeaderV2_X.cpp
@@ -65,7 +65,7 @@ RTTI_DEF1(ossimNitfImageHeaderV2_X,
           ossimNitfImageHeader);
 
 ossimNitfImageHeaderV2_X::ossimNitfImageHeaderV2_X()
-:theImageComments(0)
+:theImageComments()
 {
 }
 

--- a/src/util/ossimInfo.cpp
+++ b/src/util/ossimInfo.cpp
@@ -1418,7 +1418,19 @@ void ossimInfo::prettyPrint(const ossimFilename& file) const
    std::shared_ptr<ossimInfoBase> info = ossimInfoFactoryRegistry::instance()->create(file);
    if (info)
    {
-      info->setProcessOverviewFlag(false);
+      //---
+      // Old -d behavior was to dump all unless the dump no overview flag
+      // was set. Need to see tiff tags in file order for all image file
+      // directories(ifd's) so commenting out hard coded
+      // info->setProcessOverviewFlag(false) that used to be settable with -d
+      // + --dno options.  Note the old -d option used to do file order for
+      // tiffs but now dumps to a keyword list that prints alphabetical(not
+      // file order) so can't use that anymore.
+      // 
+      // drb - 15 Dec. 2016
+      //---
+      // info->setProcessOverviewFlag(false);
+      
       info->print(ossimNotify(ossimNotifyLevel_INFO));
       info.reset();
    }


### PR DESCRIPTION
… Implemented ossim::StreamFactory::createOstream(...) method.  Fixed tiff writer to set photo_interpretation tag to RGB if 3 band.  Removed hard coded info->setProcessOverviewFlag(false) in ossimInfo::prettyPrint(..) method to see all tiff ifds.