### PR TITLE
Add public function to clear ossimGeoidManager.

### DIFF
--- a/include/ossim/base/ossimGeoidManager.h
+++ b/include/ossim/base/ossimGeoidManager.h
@@ -68,6 +68,12 @@ public:
    virtual void addGeoid(ossimRefPtr<ossimGeoid> geoid, bool toFrontFlag=false);
 
    ossimGeoid* findGeoidByShortName(const ossimString& shortName, bool caseSensitive=true);
+
+  /**
+   * Permits to clear the GeoidList
+   */
+   virtual void clear();
+
 private:
    /**
     *  Private constructor.  Use "instance" method.

--- a/src/base/ossimGeoidManager.cpp
+++ b/src/base/ossimGeoidManager.cpp
@@ -59,6 +59,15 @@ ossimGeoidManager::~ossimGeoidManager()
 //       delete *g;
 //       ++g;
 //    }
+   clear();
+}
+
+//*****************************************************************************
+//  METHOD: ossimGeoidManager::clear()
+//
+//*****************************************************************************
+void ossimGeoidManager::clear()
+{
    theGeoidList.clear();
 }
 


### PR DESCRIPTION
Without _clear_ function in ossimGeoidManager, it seems impossible to removed Geoids.
It is annoying since I want to use ossimElevManager (which use ossimGeoidManager) sometime with and without Geoids.

If you don't want to set a public _clear_ function in ossimGeoidManager, an alternative could be to add a boolean flag to enable/disable the use of ossimGeoidManager in ossimElevManager _getHeightAboveMSL_ and _getHeightAboveEllipsoid_ functions code since the boolean flag m_useGeoidIfNullFlag is not sufficient.
