### PR TITLE
BUG:  use findPreference(const char *) instead of preferenceKWL().fin…

### DIFF
--- a/src/base/ossimStdOutProgress.cpp
+++ b/src/base/ossimStdOutProgress.cpp
@@ -38,8 +38,7 @@ ossimStdOutProgress::ossimStdOutProgress(ossim_uint32 precision,
    // running in one.
 
    ossimString stdOutConsole;
-   stdOutConsole.string() = ossimPreferences::instance()->
-      preferencesKWL().findKey(std::string("ossim.std.out.progress"));
+   stdOutConsole = ossimPreferences::instance()->findPreference("ossim.std.out.progress");
 
    if ( stdOutConsole.size() )
    {


### PR DESCRIPTION
…dKey(std::string)

    recent version of ossim dev branch makes all orfeo toolbox programs (which link with ossim) to crash with a segfault is ossimStdOutProgress

    OSSIM dev branch is installed on my linux sytem following instructions provided in ossim sources.

    This patch in ossimStdOutProgress fix the issue by using findPreference(const char *)findPreference(const char *) instead of  preferenceKWL().findKey(std::string).

    Note also that I add to change assignement of ossimString stdOutConsole, I suspect that it is also related as the crash happens in strlen.

    Note that I did not investigate to reproduce the issue outside OTB build