### PR TITLE
Ocs 2199

### DIFF
--- a/include/ossim/base/ossimIoStream.h
+++ b/include/ossim/base/ossimIoStream.h
@@ -190,8 +190,11 @@ public:
    :ossim::istream(in->rdbuf()),
    m_inputStream(in)
    {
-      m_buffer.resize(bufferSize);
-      m_inputStream->rdbuf()->pubsetbuf(&m_buffer.front(), m_buffer.size());
+      if(bufferSize > 0)
+      {
+         m_buffer.resize(bufferSize);
+         rdbuf()->pubsetbuf(&m_buffer.front(), m_buffer.size());
+      }
    }
    virtual ~ossimBufferedInputStream()
    {

--- a/include/ossim/base/ossimKeywordlist.h
+++ b/include/ossim/base/ossimKeywordlist.h
@@ -419,6 +419,26 @@ public:
    virtual bool parseStream(ossim::istream& is);
    virtual bool parseString(const std::string& inString);
 
+   /**
+   * This return the sorted keys if you have a list.
+   * Example:
+   * @code
+   * // given a keywordlist called kwl with contents: 
+   * // my.list.element1.prop
+   * // my.list.element345.prop
+   * // my.list.element22.prop
+   * std::vector<ossimString> sortedPrefixValues;
+   * kwl.getSortedList(sortedPrefixValues, "my.list.element");
+   * if(sortedPrefixValues.size())
+   * {
+   * // contents should be my.list.element1, my.list.element22, my.list.element345
+   *
+   * }
+   * @endcode
+   *
+   */
+   void getSortedList(std::vector<ossimString>& prefixValues,
+                      const ossimString &prefixKey)const;
    /*!
     *  Will return a list of keys that contain the string passed in.
     *  Later we will need to allow a user to specify regular expresion

--- a/include/ossim/base/ossimStreamFactory.h
+++ b/include/ossim/base/ossimStreamFactory.h
@@ -65,27 +65,4 @@ namespace ossim
       static StreamFactory* m_instance;
    };
 }
-
-// Deprecated code...
-class OSSIM_DLL ossimStreamFactory : public ossimStreamFactoryBase
-{
-public:
-   static ossimStreamFactory* instance();
-   virtual ~ossimStreamFactory();
-
-   virtual std::shared_ptr<ossim::ifstream>
-      createIFStream(const ossimFilename& file,
-                     std::ios_base::openmode mode) const;
-   
-   virtual ossimRefPtr<ossimIFStream>
-      createNewIFStream(const ossimFilename& file,
-                        std::ios_base::openmode mode) const;
-   
-protected:
-   ossimStreamFactory();
-   ossimStreamFactory(const ossimStreamFactory&);
-   static ossimStreamFactory* theInstance;
-   
-};
-
 #endif

--- a/include/ossim/base/ossimStreamFactoryBase.h
+++ b/include/ossim/base/ossimStreamFactoryBase.h
@@ -61,18 +61,4 @@ namespace ossim
    };
 }
 
-class OSSIM_DLL ossimStreamFactoryBase
-{
-public:
-   virtual ~ossimStreamFactoryBase(){}
-
-   virtual std::shared_ptr<ossim::ifstream>
-      createIFStream(const ossimFilename& file,
-                     std::ios_base::openmode openMode) const=0;
-   
-   virtual ossimRefPtr<ossimIFStream> createNewIFStream(
-      const ossimFilename& file,
-      std::ios_base::openmode openMode)const=0;
-};
-
 #endif

--- a/include/ossim/base/ossimStreamFactoryRegistry.h
+++ b/include/ossim/base/ossimStreamFactoryRegistry.h
@@ -22,28 +22,133 @@
 #include <vector>
 
 namespace ossim
-{
+{  
+  /**
+  * This is a generic stream registry.  We could try to create streams for
+  * http, https, s3 protocols as well as local file.  We have also exposed an
+  * exists for supporting exists() calls for different stream types.
+  *
+  * We have added support for Buffered reads.  You can enable buffered 
+  * reads to be block boundary.  If it's not block then it will use
+  * a pubsetbuf for a buffered I/O
+  * It will read the @see ossimPreferences for the prefix key
+  * ossim.stream.factory.registry.istream.buffer[0-9]+
+  * Example key list:
+  * @code
+  * ossim.stream.factory.registry.istream.buffer1.enabled: false
+  * ossim.stream.factory.registry.istream.buffer1.includePattern: ^/
+  * ossim.stream.factory.registry.istream.buffer1.enableBlocked: true
+  * ossim.stream.factory.registry.istream.buffer1.size: 65536
+  * @endcode
+  *
+  * The includePattern keyword is a regular expression.
+  * Examples:
+  *   - ^/  Anything that starts with /
+  *   - ^s3:// Anything starting with s3://
+  *
+  * Local file example:
+  * @code
+  * ossimString connectionString = "/data/foo.ntf"
+  * std::shared_ptr<ossim::istream> in = ossim::StreamFactoryRegistry::instance()->createIstream(connectionString);
+  * if(in)
+  * {
+  *   std::vector<char> buf(1024)
+  *   in->seekg(0);
+  *   in->read(&buf.front(), buf.size());
+  * }
+  * @endcode
+  * S3 file example:
+  * @code
+  * ossimString connectionString = "s3://foo-bucket/path/foo.ntf"
+  * std::shared_ptr<ossim::istream> in = ossim::StreamFactoryRegistry::instance()->createIstream(connectionString);
+  * if(in)
+  * {
+  *   std::vector<char> buf(1024)
+  *   in->seekg(0);
+  *   in->read(&buf.front(), buf.size());
+  * }
+  * @endcode
+  * https or https file example:
+  * @code
+  * ossimString connectionString = "https://foo-host/path/foo.ntf"
+  * std::shared_ptr<ossim::istream> in = ossim::StreamFactoryRegistry::instance()->createIstream(connectionString);
+  * if(in)
+  * {
+  *   std::vector<char> buf(1024)
+  *   in->seekg(0);
+  *   in->read(&buf.front(), buf.size());
+  * }
+  * @endcode
+  */
    class OSSIM_DLL StreamFactoryRegistry : public StreamFactoryBase
    {
    public:
       static StreamFactoryRegistry* instance();
       virtual ~StreamFactoryRegistry();
    
+      /**
+      * Registers a stream factory.  This allows for a pluggable stream
+      * Please see ossim-plugins and look at curl, aws for example
+      * stream definitions.
+      *
+      * @param factory To be added to the registry
+      */
       void registerFactory(StreamFactoryBase* factory);
+
+      /**
+      * Removes a factory from the registry.
+      * @param factory To be removed from the registry
+      */
       void unregisterFactory(StreamFactoryBase* factory);
 
+      /**
+      * Will try to creates an istream interface to the connectionString 
+      * passed in
+      * 
+      * @param connectionString Is the connection string used to create
+      *        a stream.  Possible examples: s3://<bucket>/path or 
+      *        /data/foo.tif or https://<host>/<path>
+      * @param options If a stream is found then this holds specific options 
+      *                for the stream. Defaults to empty options
+      * @param mode Is the mode to be used.  Defaults to a binary input stream.
+      * @return A shared pointer to an istream if successful.   
+      */
       virtual std::shared_ptr<ossim::istream>
          createIstream(const std::string& connectionString,
                        const ossimKeywordlist& options=ossimKeywordlist(),
                        std::ios_base::openmode mode=
                        std::ios_base::in|std::ios_base::binary) const;
       
+      /**
+      * Will try to creates an ostream interface to the connectionString 
+      * passed in
+      * 
+      * @param connectionString Is the connection string used to create the
+      *                         stream
+      * @param options If a stream is found then this holds specific options 
+      *                for the stream. Defaults to empty options
+      * @param mode Is the mode to be used.  Defaults to a binary output
+      *             stream.
+      * @return A shared pointer to an ostream if successful.   
+      */
       virtual std::shared_ptr<ossim::ostream>
          createOstream(const std::string& connectionString,
                        const ossimKeywordlist& options=ossimKeywordlist(),
                        std::ios_base::openmode mode=
                        std::ios_base::out|std::ios_base::binary) const;
       
+      /**
+      * Will try to creates an iostream interface to the connectionString 
+      * passed in
+      * 
+      * @param connectionString Is the connection string used to create the
+      *                         stream
+      * @param options If a stream is found then this holds specific options 
+      *                for the stream. Defaults to empty options
+      * @param mode Is the mode to be used.  Defaults to a binary output
+      *             stream.
+      * @return A shared pointer to an ostream if successful.   
+      */
       virtual std::shared_ptr<ossim::iostream>
          createIOstream(const std::string& connectionString,
                         const ossimKeywordlist& options=ossimKeywordlist(),
@@ -70,52 +175,46 @@ namespace ossim
       StreamFactoryRegistry();
       
    private:
-      class BlockInfo{
-      public:
-        BlockInfo():m_enabled(false),m_pattern(""),m_size(4096){}
 
-        bool         m_enabled;
+      /**
+      * This is an internal class used to store the buffer information
+      * loaded from the preferences.
+      * @see StreamFactoryRegistry
+      */
+      class BufferInfo{
+      public:
+        BufferInfo():m_enabled(false),
+                     m_enableBlocked(false),
+                     m_pattern(""),
+                     m_size(4096){}
+        bool                 m_enabled;
+        bool                 m_enableBlocked;
         mutable ossimRegExp  m_pattern;
-        ossim_uint64 m_size;
+        ossim_uint64         m_size;
 
       };     
       /** @brief copy constructor hidden from use */
       StreamFactoryRegistry(const StreamFactoryRegistry&);
-      void loadPatterns();
-      bool getBlocked(ossim_uint64& blockSize, 
+
+      /**
+      * This will load the buffer information from the 
+      * preferences.
+      */
+      void loadPreferences();
+
+      /**
+      * @param bufferInfo Holds the result of the first buffer info 
+      *        matching the connection string
+      * @param connecitonString The connection string
+      */
+      bool getBufferInfo(BufferInfo& bufferInfo, 
                       const ossimString& connectionString)const;
       
       std::vector<StreamFactoryBase*> m_factoryList;
-      std::vector<BlockInfo>  m_blockInfoList;
+      std::vector<BufferInfo>  m_bufferInfoList;
       static StreamFactoryRegistry*   m_instance;
    };
    
 } // End: namespace ossim
-
-// Deprecated code...
-class OSSIM_DLL ossimStreamFactoryRegistry : public ossimStreamFactoryBase
-{
-public:
-   static ossimStreamFactoryRegistry* instance();
-   virtual ~ossimStreamFactoryRegistry();
-   
-   void registerFactory(ossimStreamFactoryBase* factory);
-
-   virtual std::shared_ptr<ossim::ifstream>
-      createIFStream(const ossimFilename& file,
-                     std::ios_base::openmode openMode) const;
-   
-   virtual ossimRefPtr<ossimIFStream> createNewIFStream(
-      const ossimFilename& file, std::ios_base::openmode openMode) const;
-   
-protected:
-   ossimStreamFactoryRegistry();
-private:
-   /** @brief copy constructor hidden from use */
-   ossimStreamFactoryRegistry(const ossimStreamFactoryRegistry&);
-   
-   std::vector<ossimStreamFactoryBase*> theFactoryList;
-   static ossimStreamFactoryRegistry* theInstance;
-};
 
 #endif

--- a/include/ossim/imaging/ossimGeneralRasterTileSource.h
+++ b/include/ossim/imaging/ossimGeneralRasterTileSource.h
@@ -189,7 +189,7 @@ protected:
    ossim_uint8*                             m_buffer;
    ossim_uint8*                             m_lineBuffer;
    ossimInterleaveType                      m_bufferInterleave;
-   std::vector< std::shared_ptr<ossim::ifstream> > m_fileStrList;
+   std::vector< std::shared_ptr<ossim::istream> > m_fileStrList;
    // std::vector< std::ifstream* >            m_fileStrList;   
    ossimGeneralRasterInfo                   m_rasterInfo;
    ossimIrect                               m_bufferRect;

--- a/include/ossim/support_data/ossimSrtmSupportData.h
+++ b/include/ossim/support_data/ossimSrtmSupportData.h
@@ -197,7 +197,8 @@ private:
    ossimScalarType m_scalarType;
 
    // mutable ossimRefPtr<ossimIFStream> theFileStream;
-   mutable std::shared_ptr<ossim::ifstream> m_str;
+   mutable std::shared_ptr<ossim::istream> m_str;
+   ossimKeywordlist m_istreamOptions;
    
    template <class T>
    bool computeMinMaxTemplate(T dummy, double defaultNull);

--- a/share/ossim/templates/ossim_preferences_template
+++ b/share/ossim/templates/ossim_preferences_template
@@ -741,9 +741,11 @@ ossim.plugins.aws.s3.cacheInvalidLocations: true
 // Keywords 
 // This is used by the stream factory registry when generating 
 // input streams.  If the connection pattern matches the includePattern
-// then it will wrap that stream with an ossim::BlockIStream so that all
-// calls are done on the defined block size boundary
+// then it will wrap that stream with an ossim::BlockIStream if
+// enableBlocked is true or it will wrap with an ossimBufferedIStream
+// if enabledBlock is false
 //
-ossim.stream.factory.registry.istream.block1.enabled: false
-ossim.stream.factory.registry.istream.block1.includePattern: ^/
-ossim.stream.factory.registry.istream.block1.size: 4096
+//ossim.stream.factory.registry.istream.buffer1.enabled: false
+//ossim.stream.factory.registry.istream.buffer1.enableBlocked: false
+//ossim.stream.factory.registry.istream.buffer1.includePattern: ^/
+//ossim.stream.factory.registry.istream.buffer1.size: 65536

--- a/src/base/ossimKeywordlist.cpp
+++ b/src/base/ossimKeywordlist.cpp
@@ -1080,6 +1080,32 @@ bool ossimKeywordlist::parseStream(ossim::istream& is)
    return true;
 }
 
+void ossimKeywordlist::getSortedList(std::vector<ossimString>& prefixValues,
+                                     const ossimString &prefixKey)const
+{
+   ossimString regExpression     =  ossimString("^(") + prefixKey+ "[0-9]+)";
+   prefixValues.clear();
+   std::vector<ossimString> keys;
+   getSubstringKeyList(keys, regExpression);
+   ossim_uint32 nKeys = (long)keys.size();
+
+   ossim_uint32 offset = (int)ossimString(prefixKey).size();
+   ossim_uint32 idx = 0;
+   std::vector<ossim_uint32> numberList(nKeys);
+   for(idx = 0; idx < (int)numberList.size();++idx)
+   {
+    ossimString numberStr(keys[idx].begin() + offset,
+           keys[idx].end());
+    numberList[idx] = numberStr.toInt();
+   }
+   std::sort(numberList.begin(), numberList.end());
+
+   for(idx=0;idx < (int)numberList.size();++idx)
+   {
+      prefixValues.push_back(prefixKey+ossimString::toString(numberList[idx]));
+   }
+}
+
 std::vector<ossimString> ossimKeywordlist::findAllKeysThatContains(const ossimString &searchString)const
 {
    KeywordMap::const_iterator i;

--- a/src/base/ossimStreamFactory.cpp
+++ b/src/base/ossimStreamFactory.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<ossim::istream> ossim::StreamFactory::createIstream(
 
       result = testResult;
    }
+
    return result;
 }
       
@@ -143,92 +144,3 @@ ossim::StreamFactory::StreamFactory()
 ossim::StreamFactory::StreamFactory(const ossim::StreamFactory& )
 {
 }
-
-// Deprecated code...
-ossimStreamFactory* ossimStreamFactory::theInstance = 0;
-
-ossimStreamFactory::ossimStreamFactory(): ossimStreamFactoryBase()
-{
-}
-
-ossimStreamFactory::~ossimStreamFactory()
-{
-}
-
-ossimStreamFactory* ossimStreamFactory::instance()
-{
-   if(!theInstance)
-   {
-      theInstance = new ossimStreamFactory();
-   }
-
-   return theInstance;
-}
-
-std::shared_ptr<ossim::ifstream> ossimStreamFactory::createIFStream(
-   const ossimFilename& file, std::ios_base::openmode openMode) const
-{
-   std::shared_ptr<ossim::ifstream> result(0);
-
-   if ( file.exists() )
-   {
-      // there is a bug in gcc < 5.0 and we can't use constructors in the 
-      // C++11 build.  Will refactor to do a new ifstream then use open
-      //
-      result = std::make_shared<ossim::ifstream>();
-      result->open(file.c_str(), openMode);
-      if ( result->is_open() == false )
-      {
-         result.reset();
-      }
-   }
-   return result;
-}
-
-ossimRefPtr<ossimIFStream> ossimStreamFactory::createNewIFStream(
-   const ossimFilename& file,
-   std::ios_base::openmode mode) const
-{
-   ossimRefPtr<ossimIFStream> result = 0;
-   
-#if OSSIM_HAS_LIBZ
-   ossimFilename copyFile = file;
-
-   if(!copyFile.exists())
-   {
-      ossimString ext = copyFile.ext();
-      copyFile.setExtension("gz");
-      if(!copyFile.exists())
-      {
-         copyFile.setExtension(ext);
-         copyFile += ".gz";
-
-         if(!copyFile.exists())
-         {
-            return result;
-         }
-      }
-   }
-   
-   std::ifstream in(copyFile.c_str(), std::ios::in|std::ios::binary);
-
-   if(!in) return result;
-
-   unsigned char buf[2];
-
-   in.read((char*)buf, 2);
-   in.close();
-   // check for gzip magic number
-   //
-   if((buf[0] == 0x1F) &&
-      (buf[1] == 0x8B))
-   {
-      result = new ossimIgzStream(copyFile.c_str(), mode);
-   }
-#endif
-   return result;
-}
-
-ossimStreamFactory::ossimStreamFactory(const ossimStreamFactory&)
-   : ossimStreamFactoryBase()
-{}

--- a/src/elevation/ossimSrtmFactory.cpp
+++ b/src/elevation/ossimSrtmFactory.cpp
@@ -102,7 +102,7 @@ ossimElevSource* ossimSrtmFactory::getNewElevSource(const ossimGpt& gpt) const
    {
       srtmFileBasename += "E";
    }
-
+   ossimKeywordlist istreamOptions;
    ilon = abs(ilon);
    std::ostringstream  os2;
    os2 << std::setfill('0') << std::setw(3) << ilon;
@@ -120,32 +120,25 @@ ossimElevSource* ossimSrtmFactory::getNewElevSource(const ossimGpt& gpt) const
          << std::endl;
    }
 
-   // ossimRefPtr<ossimIFStream> is = ossimStreamFactoryRegistry::instance()->
-   std::shared_ptr<ossim::ifstream> is = ossimStreamFactoryRegistry::instance()->
-      createIFStream(srtmFile, std::ios::in | std::ios::binary);
+   std::shared_ptr<ossim::istream> is = ossim::StreamFactoryRegistry::instance()->
+      createIstream(srtmFile, istreamOptions, std::ios::in | std::ios::binary);
 
    // Look for the file mix case, then all lower case, then all upper case.
-   if ( is )
+   if ( is && is->fail())
    {
-      if(is->fail())
+      // Try down casing the whole thing.
+      srtmFileBasename = srtmFileBasename.downcase();
+      srtmFile = theDirectory.dirCat(srtmFileBasename);
+      
+      is = ossim::StreamFactoryRegistry::instance()->
+         createIstream(srtmFile, istreamOptions, std::ios::in | std::ios::binary);      
+      if ( is && is->fail())
       {
-         // Try down casing the whole thing.
-         srtmFileBasename = srtmFileBasename.downcase();
+         // OK, try upcasing the whole thing.
+         srtmFileBasename = srtmFileBasename.upcase();
          srtmFile = theDirectory.dirCat(srtmFileBasename);
-         
-         is = ossimStreamFactoryRegistry::instance()->
-            createIFStream(srtmFile, std::ios::in | std::ios::binary);      
-         if ( is )
-         {
-            if(is->fail())
-            {
-               // OK, try upcasing the whole thing.
-               srtmFileBasename = srtmFileBasename.upcase();
-               srtmFile = theDirectory.dirCat(srtmFileBasename);
-               is =  ossimStreamFactoryRegistry::instance()->
-                  createIFStream(srtmFile, std::ios::in | std::ios::binary);
-            }
-         }
+         is =  ossim::StreamFactoryRegistry::instance()->
+            createIstream(srtmFile, istreamOptions, std::ios::in | std::ios::binary);
       }
    }
 

--- a/src/imaging/ossimGeneralRasterTileSource.cpp
+++ b/src/imaging/ossimGeneralRasterTileSource.cpp
@@ -830,6 +830,7 @@ double ossimGeneralRasterTileSource::getMaxPixelValue(ossim_uint32 band)const
 
 bool ossimGeneralRasterTileSource::open()
 {
+std::cout << "ossimGeneralRasterTileSource::open(): .... entered\n";
    static const char MODULE[] = "ossimGeneralRasterTileSource::open";
 
    if (traceDebug()) CLOG << " Entered..." << std::endl;
@@ -919,26 +920,22 @@ bool ossimGeneralRasterTileSource::initializeHandler()
       ossimFilename f = aList[i];
       
       // open it...
-      std::shared_ptr<ossim::ifstream> is = ossimStreamFactoryRegistry::instance()->
-         createIFStream(f, std::ios::in|std::ios::binary);
+      std::shared_ptr<ossim::istream> is = ossim::StreamFactoryRegistry::instance()->
+         createIstream(f, std::ios::in|std::ios::binary);
 
       // check the stream...
-      if( is )
+      if( is && is->fail())
       {
          // Check the file stream.
-         if ( is->fail() )
-         {
-            theErrorStatus = ossimErrorCodes::OSSIM_ERROR;
-            ossimNotify(ossimNotifyLevel_WARN)
-               << "ossimGeneralRasterTileSource::open" << " ERROR:\n"
-               << "Cannot open:  " << f.c_str() << std::endl;
-            is = 0;
-            return false;
-         }
+         theErrorStatus = ossimErrorCodes::OSSIM_ERROR;
+         ossimNotify(ossimNotifyLevel_WARN)
+            << "ossimGeneralRasterTileSource::open" << " ERROR:\n"
+            << "Cannot open:  " << f.c_str() << std::endl;
+         is = 0;
+         return false;
       }
 
       // Check the file size (removed).
-
       m_fileStrList.push_back(is); // Add it to the list...
    }
 
@@ -1019,10 +1016,11 @@ void ossimGeneralRasterTileSource::close()
       m_lineBuffer = 0;
    }
 
-   std::vector< shared_ptr<ossim::ifstream> >::iterator is = m_fileStrList.begin();
+   std::vector< shared_ptr<ossim::istream> >::iterator is = m_fileStrList.begin();
    while (is != m_fileStrList.end())
    {
-      (*is)->close();
+      (*is) = 0;
+    //  (*is)->close();
       // delete (*is);
       // (*is) = 0;
       ++is;

--- a/src/imaging/ossimImageHandlerFactory.cpp
+++ b/src/imaging/ossimImageHandlerFactory.cpp
@@ -91,7 +91,7 @@ ossimRefPtr<ossimImageHandler> ossimImageHandlerFactory::open(
    {
       // Reset the stream for downstream code.
       str->seekg(0, std::ios_base::beg);
-      str->clear();
+      if(!str->good())str->clear();
       
       // TIFF:
       ossimRefPtr<ossimTiffTileSource> ihTiff = new ossimTiffTileSource();

--- a/src/imaging/ossimImageHandlerRegistry.cpp
+++ b/src/imaging/ossimImageHandlerRegistry.cpp
@@ -231,6 +231,7 @@ ossimRefPtr<ossimImageHandler> ossimImageHandlerRegistry::open(
       vector<ossimImageHandlerFactoryBase*>::const_iterator factory = m_factoryList.begin();
       while( factory != m_factoryList.end() )
       {
+         if(!str->good()) str->clear();
          result = (*factory)->open( str, connectionString, openOverview );
          if ( result.valid() )
          {

--- a/src/init/ossimInit.cpp
+++ b/src/init/ossimInit.cpp
@@ -144,7 +144,7 @@ void ossimInit::initialize(ossimArgumentParser& parser)
    theInstance->parsePrefsOptions(parser);
    // Stream factories must be initialized before call to: ossimPreferences::instance()
    ossim::StreamFactoryRegistry::instance()->registerFactory(ossim::StreamFactory::instance());
-   ossimStreamFactoryRegistry::instance()->registerFactory(ossimStreamFactory::instance());
+   ossim::StreamFactoryRegistry::instance()->registerFactory(ossim::StreamFactory::instance());
 
    theInstance->theAppName  = parser.getApplicationUsage()->getApplicationName();
 

--- a/src/support_data/ossimSrtmSupportData.cpp
+++ b/src/support_data/ossimSrtmSupportData.cpp
@@ -75,9 +75,8 @@ bool ossimSrtmSupportData::setFilename(const ossimFilename& srtmFile,
          << "\nscanForMinMax flag:  " << scanForMinMax
          << std::endl;
    }
-   
-   m_str =  ossimStreamFactoryRegistry::instance()->
-      createIFStream(m_file, std::ios_base::in | std::ios_base::binary);
+   m_str =  ossim::StreamFactoryRegistry::instance()->
+      createIstream(m_file, m_istreamOptions, std::ios_base::in | std::ios_base::binary);
    if (m_str)
    {
       if(m_str->fail())
@@ -164,11 +163,11 @@ bool ossimSrtmSupportData::setFilename(const ossimFilename& srtmFile,
       saveState(kwl);
       kwl.write(omdFile);
    }
-
-   if(m_str->is_open())
-   {
-      m_str->close();
-   }
+   m_str = 0;
+   // if(m_str->is_open())
+   // {
+   //    m_str->close();
+   // }
    
    if (traceDebug())
    {
@@ -669,11 +668,11 @@ bool ossimSrtmSupportData::setSize()
       ossimNotify(ossimNotifyLevel_DEBUG)
          << "ossimSrtmSupportData::setSize(): entered..." << std::endl;
    }
-
-   if(m_str->is_open() == false)
+//   if(m_str->is_open() == false)
+   if(!m_str)
    {
-      m_str = ossimStreamFactoryRegistry::instance()->createIFStream(
-         m_file, std::ios_base::in | std::ios_base::binary);
+      m_str = ossim::StreamFactoryRegistry::instance()->createIstream(
+         m_file, m_istreamOptions, std::ios_base::in | std::ios_base::binary);
    }
    
    if (!m_str)
@@ -812,7 +811,8 @@ bool ossimSrtmSupportData::setSize()
          << std::endl;
    }
 
-   m_str->close();
+   m_str = 0;
+   // m_str->close();
    
    return true;
 }
@@ -832,11 +832,13 @@ template <class T>
 bool ossimSrtmSupportData::computeMinMaxTemplate(T /* dummy */,
                                                  double defaultNull)
 {
-   if(m_str->is_open() == false)
+//   if(m_str->is_open() == false)
+   if(!m_str)
    {
       m_str =
-         ossimStreamFactoryRegistry::instance()->createIFStream(
+         ossim::StreamFactoryRegistry::instance()->createIstream(
             m_file,
+            m_istreamOptions,
             std::ios_base::in | std::ios_base::binary);
    }
    
@@ -878,7 +880,7 @@ bool ossimSrtmSupportData::computeMinMaxTemplate(T /* dummy */,
    m_minPixelValue = minValue;
    m_maxPixelValue = maxValue;
 
-   m_str->close();
+   m_str = 0;
 
    return true;
 }


### PR DESCRIPTION
Modified the StreamFactoryRegistry to support keywords from the preference file to load Blocked support at runtime.  We allow for pattern loads so we can turn on and off carrying block sizes.