### PR TITLE
fix markdown for "How to Build" section header

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to contribute code, you'll need to:
 
 The moderators will review the request and merge your changes to "dev". At that point, the automated continuous integration system (Jenkins) will get triggered to perform a build and test. If there are any failures, your merge commit will be backed out.
 
-#How to Build
+# How to Build
 The easy way is to just run the script in `ossim/scripts/build.sh`.  This approach should work for the default build configuration. This currently works for both linux and Mac. We hope to soon have a Windows `build.bat` file and world peace. Assuming all dependencies were met and no compile/link errors occured, this script will generate all build binaries under a sibling directory to the ossim repo directory, namely, `ossim/../build`. See the section on environment variables below for options on customizing the build location.
 
 This repository provides the CMAKE infrastructure necessary to build the OSSIM core library and related plugins and applications. Throughout this document, reference is made to the local, top-level directory containing this repository. We'll call this directory simply *ossim-dev-home*. (In fact, you'll find the shell variable `OSSIM_DEV_HOME` used throughout the various scripts in this and other repositories.


### PR DESCRIPTION
causing header style and anchor tag (section navigation) errors