### PR TITLE
HAd to add a pause because if someone tries to change a queue while t…

### DIFF
--- a/include/ossim/base/Barrier.h
+++ b/include/ossim/base/Barrier.h
@@ -105,12 +105,21 @@ namespace ossim{
       */
       void reset(ossim_int32 maxCount);
 
+      /**
+      * @return the maximum count
+      */
+      ossim_int32 getMaxCount()const;
+
+      /**
+      *  @return block count
+      */
+      ossim_int32 getBlockedCount()const;
 
    protected:
       ossim_int32              m_maxCount;
-      ossim_int32              m_blockedCount;
+      std::atomic<ossim_int32> m_blockedCount;
       std::atomic<ossim_int32> m_waitCount;
-      std::mutex               m_mutex;
+      mutable std::mutex       m_mutex;
       std::condition_variable  m_conditionalBlock;
 
       /**

--- a/include/ossim/parallel/ossimJobThreadQueue.h
+++ b/include/ossim/parallel/ossimJobThreadQueue.h
@@ -144,6 +144,7 @@ public:
    */
    bool hasJobsToProcess()const;
    
+
 protected:
    /**
    * Internal method.  If setJobQueue is set on this thread
@@ -156,10 +157,10 @@ protected:
    */
    virtual std::shared_ptr<ossimJob> nextJob();
    
-   bool                           m_doneFlag;
-   mutable std::mutex             m_threadMutex;
-   std::shared_ptr<ossimJobQueue> m_jobQueue;
-   std::shared_ptr<ossimJob>      m_currentJob;
+   bool                                    m_doneFlag;
+   mutable std::mutex                      m_threadMutex;
+   std::shared_ptr<ossimJobQueue>          m_jobQueue;
+   std::shared_ptr<ossimJob>               m_currentJob;
    
 };
 


### PR DESCRIPTION
…he thread is running there is a deadlock on notifications.  We have to gurantee that the thread is no longer on bocked within the previous queue and block the thread from processing anything else in the queue while we are setting to a new queue.