### PR TITLE
Oscar

### DIFF
--- a/include/ossim/base/ossimPolygon.h
+++ b/include/ossim/base/ossimPolygon.h
@@ -140,6 +140,12 @@ public:
    bool isRectWithin(const ossimIrect &rect) const;
 
    /**
+   * METHOD: rectIntersects()
+   * Returns true if at least one corner points of the given rect is within.
+   */
+   bool rectIntersects(const ossimIrect &rect) const;
+
+   /**
    * METHOD: isPolyWithin()
    * Returns true if all the vertices of the given polygon fit within.
    */

--- a/src/base/ossimPolygon.cpp
+++ b/src/base/ossimPolygon.cpp
@@ -434,6 +434,19 @@ bool ossimPolygon::isRectWithin(const ossimIrect &rect) const
     }
     return false;
 }
+
+bool ossimPolygon::rectIntersects(const ossimIrect &rect) const
+{
+   if (  isPointWithin(rect.ul()) ||
+         isPointWithin(rect.ur()) ||
+         isPointWithin(rect.ll()) ||
+         isPointWithin(rect.lr()))
+   {
+      return true;
+   }
+   return false;
+}
+
 /**
 * METHOD: isPolyWithin()
 * Returns true if all the vertices of the given polygon fit within.

--- a/src/imaging/ossimImageHandler.cpp
+++ b/src/imaging/ossimImageHandler.cpp
@@ -286,52 +286,29 @@ bool ossimImageHandler::initVertices(const char* file)
 
    // Clean out any old vertices...
    theValidImageVertices.clear();
-
-   ossim_uint32 number_of_points = kwl.numberOf("point", "x");
-
-   for (ossim_uint32 i=0; i<number_of_points; ++i)
+   std::vector<ossimString> indexedPrefixes;
+   kwl.getSortedList(indexedPrefixes, "point");
+   ossim_uint32 number_of_points = indexedPrefixes.size();
+   for (ossim_uint32 i=0; i<number_of_points; i++)
    {
       ossimIpt pt;
       const char* lookup;
-      ossimString p = "point";
-      p += ossimString::toString(i);
-      
-      ossimString px = p + ".x";
-      lookup = kwl.find(px.c_str());
+      lookup = kwl.find(indexedPrefixes[i], ".x");
       if (lookup)
       {
          pt.x = atoi(lookup);
+         lookup = kwl.find(indexedPrefixes[i], ".y");
+         if (lookup)
+            pt.y = atoi(lookup);
       }
-      else
+
+      if (!lookup)
       {
          if (traceDebug())
-         {
-            CLOG << " ERROR:"
-                 << "\nlookup failed for:  " << px.c_str()
-                 << "\nReturning..."
-                 << std::endl;
-         }
+            CLOG << " ERROR: lookup failed for: " << indexedPrefixes[i] << std::endl;
          return false;
       }
          
-      ossimString py = p + ".y";
-      lookup = kwl.find(py.c_str());
-      if (lookup)
-      {
-         pt.y = atoi(lookup);
-      }
-      else
-      {
-         if (traceDebug())
-         {
-            CLOG << " ERROR:"
-                 << "\nLookup failed for:  " << py.c_str()
-                 << "\nReturning..."
-                 << std::endl;
-         }
-         return false;
-      }
-
       theValidImageVertices.push_back(pt);
    }
 


### PR DESCRIPTION
Tested fix in ossimImageHandler after finding that it was incorrectly reading vertices from a vertices file. 

Also added a new method to ossimPolygon to check if a rect intersects the polygon. Existing method isRectWithin() only true if all corners are inside. rectIntersects() just needs one corner inside. Used for auto-tie-point code.