### PR TITLE
Fixed compliation error on Mac OS Sierra (XCode 8.3)

### DIFF
--- a/include/ossim/base/ossimRefPtr.h
+++ b/include/ossim/base/ossimRefPtr.h
@@ -8,6 +8,7 @@
 #define ossimRefPtr_HEADER
 #include <ossim/base/ossimConstants.h>
 #include <stddef.h>
+#include <cstddef>
 
 template<class T> class ossimRefPtr
 {
@@ -100,20 +101,20 @@ template<typename _Tp1, typename _Tp2> inline bool
   operator==(const ossimRefPtr<_Tp1>& __a, const ossimRefPtr<_Tp2>& __b) noexcept
   { return __a.get() == __b.get(); }
 
-template<typename _Tp> inline bool operator==(const ossimRefPtr<_Tp>& __a, nullptr_t) noexcept
+template<typename _Tp> inline bool operator==(const ossimRefPtr<_Tp>& __a, std::nullptr_t) noexcept
   { return !__a; }
 
-template<typename _Tp> inline bool operator==(nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
+template<typename _Tp> inline bool operator==(std::nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
   { return !__a; }
 
 template<typename _Tp1, typename _Tp2>  inline bool
   operator!=(const ossimRefPtr<_Tp1>& __a, const ossimRefPtr<_Tp2>& __b) noexcept
   { return __a.get() != __b.get(); }
 
-template<typename _Tp> inline bool operator!=(const ossimRefPtr<_Tp>& __a, nullptr_t) noexcept
+template<typename _Tp> inline bool operator!=(const ossimRefPtr<_Tp>& __a, std::nullptr_t) noexcept
   { return (bool)__a; }
 
-template<typename _Tp> inline bool operator!=(nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
+template<typename _Tp> inline bool operator!=(std::nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
   { return (bool)__a; }
 
 


### PR DESCRIPTION
While attempting to build the latest version of ossim for inclusion in [homebrew-osgeo4mac](https://github.com/OSGeo/homebrew-osgeo4mac), we ran into the following error while building on Travis in Mac OS Sierra (Xcode 8.3.3.)

```
Scanning dependencies of target ossim
/Applications/Xcode8.3.3.app/Contents/Developer/usr/bin/make -f src/CMakeFiles/ossim.dir/build.make src/CMakeFiles/ossim.dir/build
[  0%] Building CXX object src/CMakeFiles/ossim.dir/init/JsonConfig.cpp.o
cd /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/build/src && /Applications/Xcode8.3.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -Dossim_EXPORTS -I/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include -I/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/build/include -I/usr/local/include -I/usr/local/include/freetype2  -std=c++11 -DNDEBUG -fPIC    -fPIC -std=c++11 -o CMakeFiles/ossim.dir/init/JsonConfig.cpp.o -c /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/src/init/JsonConfig.cpp
[  0%] Building CXX object src/CMakeFiles/ossim.dir/init/ossimInit.cpp.o
cd /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/build/src && /Applications/Xcode8.3.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -Dossim_EXPORTS -I/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include -I/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/build/include -I/usr/local/include -I/usr/local/include/freetype2  -std=c++11 -DNDEBUG -fPIC    -fPIC -std=c++11 -o CMakeFiles/ossim.dir/init/ossimInit.cpp.o -c /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/src/init/ossimInit.cpp
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/src/init/ossimInit.cpp:32:
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimGeoidManager.h:19:
/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimRefPtr.h:103:76: error: unknown type name
      'nullptr_t'; did you mean 'std::nullptr_t'?
template<typename _Tp> inline bool operator==(const ossimRefPtr<_Tp>& __a, nullptr_t) noexcept
                                                                           ^~~~~~~~~
                                                                           std::nullptr_t
/Applications/Xcode8.3.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstddef:97:31: note:
      'std::nullptr_t' declared here
    typedef decltype(nullptr) nullptr_t;
                              ^
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/src/init/ossimInit.cpp:32:
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimGeoidManager.h:19:
/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimRefPtr.h:106:47: error: C++ requires a type
      specifier for all declarations
template<typename _Tp> inline bool operator==(nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
                                              ^
/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimRefPtr.h:113:76: error: unknown type name
      'nullptr_t'; did you mean 'std::nullptr_t'?
template<typename _Tp> inline bool operator!=(const ossimRefPtr<_Tp>& __a, nullptr_t) noexcept
                                                                           ^~~~~~~~~
                                                                           std::nullptr_t
/Applications/Xcode8.3.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstddef:97:31: note:
      'std::nullptr_t' declared here
    typedef decltype(nullptr) nullptr_t;
                              ^
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/src/init/ossimInit.cpp:32:
In file included from /Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimGeoidManager.h:19:
/Users/nickrobison/Developer/external/ossim-Gasparilla-2.3.1/include/ossim/base/ossimRefPtr.h:116:47: error: C++ requires a type
      specifier for all declarations
template<typename _Tp> inline bool operator!=(nullptr_t, const ossimRefPtr<_Tp>& __a) noexcept
                                              ^
4 errors generated.
make[2]: *** [src/CMakeFiles/ossim.dir/init/ossimInit.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/ossim.dir/all] Error 2
make: *** [all] Error 2
```

This patch adds the std namespace to nullptr_t references and includes the `<cstddef>` header, which resolves the compilation error. I've tested on both Mac OS Sierra and High Sierra, using the latest Xcode 9.3

Thanks for the great work on an excellent project!