### PR TITLE
Fix spelling errors.

### DIFF
--- a/apps/ossim-pixelflip/ossim-pixelflip.cpp
+++ b/apps/ossim-pixelflip/ossim-pixelflip.cpp
@@ -385,7 +385,7 @@ void usage()
       << "\nThis is a good Landsat7 edge fixer..."
       << "\n"
       << "\nIf mode is \"replace_full_targets\":"
-      << "\nTarget will be repaced only if all subpixels(bands) have the "
+      << "\nTarget will be replaced only if all subpixels(bands) have the "
       << "target."
       << "\n"
       << "\n Example:"

--- a/apps/ossim-rpcgen/ossim-rpcgen.cpp
+++ b/apps/ossim-rpcgen/ossim-rpcgen.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
          argumentParser.getApplicationName() + " takes an input image and generates a "
          "corresponding RPC geometry in a variety of formats. If a bounding box is specified, the "
          "default output filename (based on the input filename) will be appended with the bbox spec"
-         ", unless an output filename is explicitely provided.");
+         ", unless an output filename is explicitly provided.");
    au->setCommandLineUsage(
          argumentParser.getApplicationName() + " [options] <input-file> [<output-file>]");
    au->addCommandLineOption(

--- a/include/ossim/imaging/ossimSingleImageChain.h
+++ b/include/ossim/imaging/ossimSingleImageChain.h
@@ -473,7 +473,7 @@ public:
    void setBrightnessContrastFlag(bool flag);
 
    /**
-    * @brief Get the brightness constrast flag.
+    * @brief Get the brightness contrast flag.
     * @return true or false.
     */
    bool getBrightnessContrastFlag() const;

--- a/share/ossim/templates/ossim_preferences_template
+++ b/share/ossim/templates/ossim_preferences_template
@@ -687,8 +687,8 @@ tfrd_iamp_file: $(OSSIM_INSTALL_PREFIX)/share/ossim/tfrd-tables/oamt.dat
 // allows on to specify configuration options and parsing for the hdf5 plugin
 // In this example we have only the Radiance file supported for VIIRS data
 // to get a listing of dataset use the ossim-info -d on any hdf5 dataset file
-// and look at the top for the dataset comma seperated list of dataset paths.
-// You can add a comma seperated list for renderable_datasets and only those will show
+// and look at the top for the dataset comma separated list of dataset paths.
+// You can add a comma separated list for renderable_datasets and only those will show
 // up in an ossim-info
 // 
 hdf5.options.max_recursion_level: 8

--- a/src/base/ossimDatumFactory.inc
+++ b/src/base/ossimDatumFactory.inc
@@ -153,7 +153,7 @@ static ossimThreeParamDatumType threeParamDatum[] = {
 {"LCF", "L.C. 5 ASTRO 1961, Cayman Brac", "CC", 25, 25, 25, -81, -78, 18, 21, 42, 124, 147},
 {"LEH", "LEIGON, Ghana", "CD", 2, 3, 2, -9, 7, -1, 17, -130, 29, 364},
 {"LIB", "LIBERIA 1964", "CD", 15, 15, 15, -17, -1, -1, 14, -90, 40, 88},
-{"LUZ-A", "LUZON, Phillipines", "CC", 8, 11, 9, 115, 128, 3, 23, -133, -77, -51},
+{"LUZ-A", "LUZON, Philippines", "CC", 8, 11, 9, 115, 128, 3, 23, -133, -77, -51},
 {"LUZ-B", "LUZON, Mindanao Island", "CC", 25, 25, 25, 120, 128, 4, 12, -133, -79, -72},
 {"MAS", "MASSAWA, Ethiopia", "BR", 25, 25, 25, 37, 53, 7, 25, 639, 405, 60},
 {"MER", "MERCHICH, Morocco", "CD", 5, 3, 3, -19, 5, 22, 42, 31, 146, 47},

--- a/src/hdf5/ossimHdf5Tool.cpp
+++ b/src/hdf5/ossimHdf5Tool.cpp
@@ -221,7 +221,7 @@ void ossimHdf5Tool::loadImageFiles()
    }
    else
    {
-      // Use explicitely-provided dataset names:
+      // Use explicitly-provided dataset names:
       handler = new ossimHdf5ImageHandler;
       handler->addRenderable(m_imageDataPath);
       handler->setFilename(ossimFilename(value));

--- a/src/imaging/ossimCcfTileSource.cpp
+++ b/src/imaging/ossimCcfTileSource.cpp
@@ -611,7 +611,7 @@ bool ossimCcfTileSource::setOutputBandList(const vector<ossim_uint32>& outputBan
                  << "\nOutput band number in list is greater than the "
                  << "number of bands in the image source!"
                  << "\noutputBandList[" << i << "]:  "
-                 << "\nHighest availabe band:  "
+                 << "\nHighest available band:  "
                  << (getNumberOfInputBands() - 1)
                  << "\nError status has been set!  Returning..."
                  << endl;

--- a/src/imaging/ossimGeneralRasterInfo.cpp
+++ b/src/imaging/ossimGeneralRasterInfo.cpp
@@ -72,7 +72,7 @@ SET_NULLS("set_fill_to_nulls_mode",
 
 static const ossimKeyword
 PIXELS_TO_CHOP("pixels_to_chop",
-               "Ammount of pixels to chop from edge.");
+               "Amount of pixels to chop from edge.");
 
 static const ossimInterleaveTypeLut INTERLEAVE_TYPE_LUT;
 

--- a/src/imaging/ossimImageChain.cpp
+++ b/src/imaging/ossimImageChain.cpp
@@ -1505,7 +1505,7 @@ void ossimImageChain::initialize()
    {
       if(traceDebug())
       {
-         CLOG << "initilizing source: "
+         CLOG << "initializing source: "
               << imageChainList()[index]->getClassName()
               << std::endl;
       }

--- a/src/imaging/ossimImageSourceSequencer.cpp
+++ b/src/imaging/ossimImageSourceSequencer.cpp
@@ -388,7 +388,7 @@ ossimRefPtr<ossimImageData> ossimImageSourceSequencer::getTile(
    {
       if(traceDebug())
       {
-         CLOG << "No input connection so returing NULL" << endl;
+         CLOG << "No input connection so returning NULL" << endl;
       }
    }
    if(traceDebug())

--- a/src/imaging/ossimTiffOverviewBuilder.cpp
+++ b/src/imaging/ossimTiffOverviewBuilder.cpp
@@ -1273,7 +1273,7 @@ bool ossimTiffOverviewBuilder::setInputSource(ossimImageHandler* imageSource)
             setErrorStatus();
             ossimNotify(ossimNotifyLevel_WARN)
                << MODULE << " ERROR:"
-               << "\nUnknow pixel type:  "
+               << "\nUnknown pixel type:  "
                << (ossimScalarTypeLut::instance()->
                    getEntryString(m_imageHandler->getOutputScalarType()))
                << std::endl;

--- a/src/support_data/ossimTiffInfo.cpp
+++ b/src/support_data/ossimTiffInfo.cpp
@@ -334,7 +334,7 @@ std::ostream &ossimTiffInfo::print(std::ostream &out) const
          if (traceDebug())
          {
             ossimNotify(ossimNotifyLevel_WARN)
-                << MODULE << " FATAL error reading number of direcories."
+                << MODULE << " FATAL error reading number of directories."
                 << std::endl;
          }
          m_inputStream.reset();
@@ -767,7 +767,7 @@ std::ostream &ossimTiffInfo::print(std::istream &inStr,
          if (traceDebug())
          {
             ossimNotify(ossimNotifyLevel_WARN)
-                << MODULE << " FATAL error reading number of direcories."
+                << MODULE << " FATAL error reading number of directories."
                 << std::endl;
          }
          return outStr;

--- a/src/util/ossimChipProcTool.cpp
+++ b/src/util/ossimChipProcTool.cpp
@@ -1111,7 +1111,7 @@ void ossimChipProcTool::initializeAOI()
       // Geo-scaled projection needs to know the reference latitude:
       if (m_geoScaled)
       {
-         // The origin may have ben explicitely specified,or just use midpoint of AOI:
+         // The origin may have ben explicitly specified,or just use midpoint of AOI:
          ossimGpt origin;
          if (!getProjectionOrigin(origin))
             origin = m_aoiGroundRect.midPoint();

--- a/src/util/ossimChipperUtil.cpp
+++ b/src/util/ossimChipperUtil.cpp
@@ -210,11 +210,11 @@ void ossimChipperUtil::addArguments(ossimArgumentParser &ap)
 
    au->addCommandLineOption("--central-meridian", "<central_meridian_in_decimal_degrees>\nNote if set this will be used for the central meridian of the projection.  This can be used to lock the utm zone.");
 
-   au->addCommandLineOption("--color", "<r> <g> <b>\nhillshade option - Set the red, green and blue color values to be used with hillshade.\nThis option can be used with or without an image source for color.\nRange 0 to 255, Defualt r=255, g=255, b=255");
+   au->addCommandLineOption("--color", "<r> <g> <b>\nhillshade option - Set the red, green and blue color values to be used with hillshade.\nThis option can be used with or without an image source for color.\nRange 0 to 255, Default r=255, g=255, b=255");
 
    au->addCommandLineOption("--color-table", "<color-table.kwl>\nhillshade or color-relief option - Keyword list containing color table for color-relief option.");
 
-   au->addCommandLineOption("--contrast", "<constrast>\nApply constrast to input image(s). Valid range: -1.0 to 1.0");
+   au->addCommandLineOption("--contrast", "<contrast>\nApply contrast to input image(s). Valid range: -1.0 to 1.0");
 
    au->addCommandLineOption("--cut-bbox-xywh", "<x>,<y>,<width>,<height>\nSpecify a comma separated bounding box.");
 
@@ -247,7 +247,7 @@ void ossimChipperUtil::addArguments(ossimArgumentParser &ap)
 
    au->addCommandLineOption("--exaggeration", "<factor>\nMultiplier for elevation values when computing surface normals. Has the effect of lengthening shadows for oblique lighting.\nRange: .0001 to 50000, Default = 1.0");
 
-   au->addCommandLineOption("--fullres-xys", "<full res center x>,<full res center y>,<scale>[,<scale>]\nSpecify a full resolution x,y point (Used as pivot and center cut) and scale, comma seperated with no spaces.  If two scales are specified then first is x and second is y else x and y are set to equal scales");
+   au->addCommandLineOption("--fullres-xys", "<full res center x>,<full res center y>,<scale>[,<scale>]\nSpecify a full resolution x,y point (Used as pivot and center cut) and scale, comma separated with no spaces.  If two scales are specified then first is x and second is y else x and y are set to equal scales");
 
    au->addCommandLineOption("-h or --help", "Display this help and exit.");
 
@@ -1890,7 +1890,7 @@ ossimRefPtr<ossimSingleImageChain> ossimChipperUtil::createChain(const ossimFile
             setupChainHistogram(ic);
          }
 
-         // Brightness constrast setup:
+         // Brightness contrast setup:
          if (hasBrightnesContrastOperation())
          {
             // Assumption bright contrast filter in chain:
@@ -2076,7 +2076,7 @@ ossimRefPtr<ossimSingleImageChain> ossimChipperUtil::createChain(const ossimSrcR
          setupChainHistogram(ic, std::make_shared<ossimSrcRecord>(rec));
       }
 
-      // Brightness constrast setup:
+      // Brightness contrast setup:
       if (hasBrightnesContrastOperation())
       {
          // Assumption bright contrast filter in chain:
@@ -2305,7 +2305,7 @@ void ossimChipperUtil::rotateMapToInput()
       if (!mapProj)
          throw ossimException("Output projection must be a map projection.");
       if (m_imgLayer.size() != 1)
-         throw ossimException("Optimal rotation output requested but this feature is not avaliable for mosaics.");
+         throw ossimException("Optimal rotation output requested but this feature is not available for mosaics.");
       ossimRefPtr<ossimImageHandler> ih = m_imgLayer[0]->getImageHandler();
       if (!ih)
          throw ossimException("Null image handler encountered.");

--- a/src/util/ossimHillshadeTool.cpp
+++ b/src/util/ossimHillshadeTool.cpp
@@ -233,7 +233,7 @@ void ossimHillshadeTool::setUsage(ossimArgumentParser& ap)
 
    // Add arguments.
    au->addCommandLineOption("--azimuth", "<azimuth>\nLight source azimuth angle for bump shade.\nRange: 0 to 360, Default = 180.0");
-   au->addCommandLineOption("--color","<r> <g> <b>\nSet the red, green and blue color values to be used with hillshade.\nRange 0 to 255, Defualt r=255, g=255, b=255");
+   au->addCommandLineOption("--color","<r> <g> <b>\nSet the red, green and blue color values to be used with hillshade.\nRange 0 to 255, Default r=255, g=255, b=255");
    au->addCommandLineOption("--color-source","<file>\nSpecifies the image file to use as a color source instead of a fixed RGB value.");
    au->addCommandLineOption("--elevation", "<elevation>\nhillshade option - Light source elevation angle for bumb shade.\nRange: 0 to 90, Default = 45.0");
 

--- a/src/util/ossimHlzTool.cpp
+++ b/src/util/ossimHlzTool.cpp
@@ -104,7 +104,7 @@ void ossimHlzTool::setUsage(ossimArgumentParser& ap)
          "Number of threads. Defaults to use single core. For engineering/debug purposes.");
    au->addCommandLineOption("--use-slope",
          "Slope is computed from the normal vector using neighboring posts instead of "
-         "least-squares fit to a plane (prefered). For engineering/debug purposes.");
+         "least-squares fit to a plane (preferred). For engineering/debug purposes.");
 }
 
 bool ossimHlzTool::initialize(ossimArgumentParser& ap)


### PR DESCRIPTION
The lintian QA tool reported several spelling errors:

 * Phillipines -> Philippines
 * availabe    -> available
 * Ammount     -> Amount
 * initilizing -> initializing
 * Unknow      -> Unknown
 * direcories  -> directories
 * Defualt     -> Default
 * prefered    -> preferred
 * repaced     -> replaced
 * explicitely -> explicitly
 * constrast   -> contrast
 * seperated   -> separated
 * avaliable   -> available