### PR TITLE
Fixed overwrite of IVT in constructor and loadState()

### DIFF
--- a/src/imaging/ossimImageRenderer.cpp
+++ b/src/imaging/ossimImageRenderer.cpp
@@ -1105,7 +1105,6 @@ ossimImageRenderer::ossimImageRenderer(ossimImageSource *inputSource,
       m_Tile(0),
       m_TemporaryBuffer(0),
       m_StartingResLevel(0),
-      m_ImageViewTransform(imageViewTrans),
       m_inputR0Rect(),
       m_viewRect(),
       m_rectsDirty(true),
@@ -1118,12 +1117,9 @@ ossimImageRenderer::ossimImageRenderer(ossimImageSource *inputSource,
 {
    ossimViewInterface::theObject = this;
    m_Resampler = new ossimFilterResampler();
-   if(!m_ImageViewTransform.valid())
-   {
-      m_ImageViewTransform = new ossimImageViewProjectionTransform;
-   }
 
    loadState(ossimPreferences::instance()->preferencesKWL(), "renderer.");
+   m_ImageViewTransform = imageViewTrans;
 }
 
 ossimImageRenderer::~ossimImageRenderer()


### PR DESCRIPTION
Hot fix for IVT in ossimImageRenderer constructor