### PR TITLE
Remap

### DIFF
--- a/include/ossim/projection/ossimImageViewAffineTransform.h
+++ b/include/ossim/projection/ossimImageViewAffineTransform.h
@@ -17,6 +17,20 @@
 class OSSIMDLLEXPORT ossimImageViewAffineTransform: public ossimImageViewTransform
 {
 public:
+   /**
+    * Initialize transform completely here. The image-to-view transform is a chain of 3x3 matrix
+    * multiplies as: [translation] [view scale] [rotation (about pivot pt)] [image scale].
+    * The view to image is stored as the inverse transform.
+    * @param rotateDegrees
+    * @param imageScaleX  Image-side scale, applied before rotation
+    * @param imageScaleY  ditto
+    * @param scaleXValue  View-side scale
+    * @param scaleYValue  ditto
+    * @param translateXValue View-side translation
+    * @param translateYValue  ditto
+    * @param pivotXValue Pivot point in image space
+    * @param pivotYValue ditto
+    */
    ossimImageViewAffineTransform(double rotateDegrees = 0.0,
                                  double imageScaleX = 1.0,
                                  double imageScaleY = 1.0,

--- a/include/ossim/util/ossimRemapTool.h
+++ b/include/ossim/util/ossimRemapTool.h
@@ -54,6 +54,7 @@ protected:
    bool m_doHistoStretch;
    ossimFilename m_inputFilename;
    uint32_t m_entry;
+   double m_gsd;
 };
 
 #endif

--- a/src/base/ossim2dTo2dTransformFactory.cpp
+++ b/src/base/ossim2dTo2dTransformFactory.cpp
@@ -13,6 +13,7 @@
 #include <ossim/base/ossim2dTo2dShiftTransform.h>
 #include <ossim/base/ossim2dTo2dIdentityTransform.h>
 #include <ossim/base/ossim2dTo2dCompositeTransform.h>
+#include <ossim/base/ossimAffineTransform.h>
 #include <ossim/base/ossimKeywordNames.h>
 #include <ossim/base/ossimKeywordlist.h>
 #include <ossim/base/ossimRefPtr.h>
@@ -46,7 +47,11 @@ ossim2dTo2dTransform* ossim2dTo2dTransformFactory::createTransform(const ossimSt
    {
       result = new ossim2dTo2dCompositeTransform();
    }
-   
+   else if(name == STATIC_TYPE_NAME(ossimAffineTransform))
+   {
+      result = new ossimAffineTransform();
+   }
+
    return result;
 }
 
@@ -69,5 +74,5 @@ void ossim2dTo2dTransformFactory::getTypeNameList(std::vector<ossimString>& type
    typeList.push_back(STATIC_TYPE_NAME(ossim2dTo2dShiftTransform));
    typeList.push_back(STATIC_TYPE_NAME(ossim2dTo2dIdentityTransform));
    typeList.push_back(STATIC_TYPE_NAME(ossim2dTo2dCompositeTransform));
-   
+   typeList.push_back(STATIC_TYPE_NAME(ossimAffineTransform));
 }


### PR DESCRIPTION
Addition of ossimTool-derived utility for specific processing: remap to 8-bit, histo stretch, and down-sampling. Usage:

```
ossim-cli remap [options] <input-image> [<output-image>]

Description:
Performs remap to 8-bit including optional histogram stretch and saves
the corresponding external geometry file.

Options:
  All ossimTool options, plus:
  -e, --entry                  <entry> For multi image handlers which entry do
                               you wish to extract. For list of entries use:
                               "ossim-info -i <your_image>" 
  -g, --gsd                    Set the output resolution, in meters. Default is
                               same as input resolution (no resampling).
  -n, --no-histo               Optionally bypass histogram-stretch. 
```