### PR TITLE
Eleaver rpcmodel hdf5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ INCLUDE(OssimCommonVariables)
 # Expose some build options
 set(LIB_NAME ossim CACHE STRING "Name of ossim libray (default is ossim).")
 OPTION(BUILD_OSSIM_FREETYPE_SUPPORT "Set to ON to build OSSIM with freetype support.  Use OFF to turn off freetype support." ON)
-OPTION(BUILD_OSSIM_HDF5_SUPPORT "Set to ON to build OSSIM with HDF5 support.  Use OFF to turn off MPI support." OFF)
+OPTION(BUILD_OSSIM_HDF5_SUPPORT "Set to ON to build OSSIM with HDF5 support.  Use OFF to turn off HDF5 support." OFF)
 OPTION(BUILD_OSSIM_MPI_SUPPORT "Set to ON to build OSSIM with MPI support.  Use OFF to turn off MPI support." OFF)
 OPTION(BUILD_OSSIM_ID_SUPPORT "Set to ON to build OSSIM GIT ID support into the library.  Use OFF to turn off ID support." ON)
 
@@ -181,9 +181,11 @@ set( OSSIM_HAS_MPI 0 )
 if( BUILD_OSSIM_MPI_SUPPORT )
    find_package(MPI)
    if ( MPI_FOUND )
+      # /usr/share/cmake/Modules/FindMPI.cmae are not consistent in terminology,
+      # so we include multiple list names, knowing some will be empty
       include_directories( ${MPI_INCLUDE_DIR} )
-      include_directories( ${MPI_CXX_INCLUDE_DIRS} )
-      include_directories( ${MPI_C_INCLUDE_DIRS} )
+      include_directories( ${MPI_CXX_INCLUDE_PATH} ${MPI_CXX_INCLUDE_DIRS} )
+      include_directories( ${MPI_C_INCLUDE_PATH} ${MPI_C_INCLUDE_DIRS} )
       set( ossimDependentLibs ${ossimDependentLibs} ${MPI_LIBRARIES} )
       set( OSSIM_HAS_MPI 1 )
    else ( MPI_FOUND )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,29 @@
 PROJECT(ossim)
+############################################################
+# From https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+#
+# Use, don't skip, the full RPATH for the build tree
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+# When building, don't use the install RPATH already
+# (but later on when installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif("${isSystemDir}" STREQUAL "-1")
+#################################################################
+
+
+
 SET(CMAKE_MODULE_PATH "${${PROJECT_NAME}_SOURCE_DIR}/cmake/CMakeModules;${CMAKE_MODULE_PATH}")
 
 set(CMAKE_CXX_STANDARD 11)
@@ -23,6 +48,7 @@ INCLUDE(OssimCommonVariables)
 # Expose some build options
 set(LIB_NAME ossim CACHE STRING "Name of ossim libray (default is ossim).")
 OPTION(BUILD_OSSIM_FREETYPE_SUPPORT "Set to ON to build OSSIM with freetype support.  Use OFF to turn off freetype support." ON)
+OPTION(BUILD_OSSIM_HDF5_SUPPORT "Set to ON to build OSSIM with HDF5 support.  Use OFF to turn off MPI support." OFF)
 OPTION(BUILD_OSSIM_MPI_SUPPORT "Set to ON to build OSSIM with MPI support.  Use OFF to turn off MPI support." OFF)
 OPTION(BUILD_OSSIM_ID_SUPPORT "Set to ON to build OSSIM GIT ID support into the library.  Use OFF to turn off ID support." ON)
 
@@ -156,6 +182,8 @@ if( BUILD_OSSIM_MPI_SUPPORT )
    find_package(MPI)
    if ( MPI_FOUND )
       include_directories( ${MPI_INCLUDE_DIR} )
+      include_directories( ${MPI_CXX_INCLUDE_DIRS} )
+      include_directories( ${MPI_C_INCLUDE_DIRS} )
       set( ossimDependentLibs ${ossimDependentLibs} ${MPI_LIBRARIES} )
       set( OSSIM_HAS_MPI 1 )
    else ( MPI_FOUND )

--- a/include/ossim/projection/ossimRpcModel.h
+++ b/include/ossim/projection/ossimRpcModel.h
@@ -66,6 +66,9 @@ public:
    /** @brief copy construtor */
    ossimRpcModel(const ossimRpcModel& copy_this);
 
+   /** @brief virtual destructor */
+   virtual ~ossimRpcModel();
+
    void setAttributes(ossim_float64 theSampleOffset,
                       ossim_float64 theLineOffset,
                       ossim_float64 theSampleScale,
@@ -240,9 +243,6 @@ protected:
       NUM_ADJUSTABLE_PARAMS // not an index
    };
 
-   /** @brief virtual destructor */
-   virtual ~ossimRpcModel();
-   
    //***
    // Methods for computing RPC polynomial and its derivatives:
    //***


### PR DESCRIPTION
1. Made ~ossimRpcModel() dtor public rather than protected. I assume this had been an oversight?
2. CMakeLists.txt:
    a. Added an explicit OPTION(BUILD_OSSIM_HDF5_SUPPORT) that may be set from command line
    b. To improve MPI support, added
        include_directories( ${MPI_CXX_INCLUDE_PATH} ${MPI_CXX_INCLUDE_DIRS} )
        include_directories( ${MPI_C_INCLUDE_PATH} ${MPI_C_INCLUDE_DIRS} )
    These are in addition to the extant include_directories( ${MPI_INCLUDE_DIR} )
    MPI_INCLUDE_DIR is not set by my /usr/share/cmake/Modules/FindMPI.cmake, but might be by someone else's.
    c. Added some general CMake boilerplate to enable RPATH support by default. I tripped over this when I configured ossim with MPI and tried to load a shared library from a client application. It was easier to add RPATH to ossim's CMakeLists.txt once, than try to maintain disparate client LD_LIBRARY_PATHs in perpetuity; I hope you can accept it.

I've tested this build on Fedora-32, CentOS-7, and CentOS-8.
a. Fedora-32 and CentOS-8's /usr/share/cmake/Modules/FindMPI.cmake set MPI_C_INCLUDE_DIRS, while CentOS-7 sets MPI_C_INCLUDE_PATH. Same for CXX.
b. HDF5 doesn't build on CentOS-7 as it's /usr/include/H5Object does not define getObjName().
c. Otherwise CentOS-7 builds fine, with the caveate that on CentOS-7 one might need to manually edit /usr/include/jsoncpp/json/value.h and change "bool operator!() const;" to "bool operator!() const { return isNull(); };" -- at least with epel jsoncpp-devel version 0.10.5.

I've attached my configuration script, ConfigureOssim.sh.txt
[ConfigureOssim.sh.txt](https://github.com/ossimlabs/ossim/files/4663813/ConfigureOssim.sh.txt)


