### PR TITLE
Drb 20200909

### DIFF
--- a/include/ossim/elevation/ossimElevManager.h
+++ b/include/ossim/elevation/ossimElevManager.h
@@ -1,7 +1,7 @@
 //*****************************************************************************
 // FILE: ossimElevManager.h
 //
-// License:  See top level LICENSE.txt file.
+// License: MIT
 //
 // DESCRIPTION:
 //   Contains declaration of class ossimElevManager. This object provides a
@@ -18,14 +18,16 @@
 //<
 //*****************************************************************************
 #ifndef ossimElevManager_HEADER
-#define ossimElevManager_HEADER
+#define ossimElevManager_HEADER 1
 
-#include <vector>
 #include <ossim/base/ossimConstants.h>
 #include <ossim/base/ossimVisitor.h>
 #include <ossim/elevation/ossimElevSource.h>
 #include <ossim/elevation/ossimElevationDatabase.h>
 #include <mutex>
+#include <vector>
+
+class ossimFilename;
 
 class OSSIM_DLL ossimElevManager : public ossimElevSource
 {
@@ -96,6 +98,33 @@ public:
    void setDefaultHeightAboveEllipsoid(double meters) {m_defaultHeightAboveEllipsoid=meters;}
    void setElevationOffset(double meters) {m_elevationOffset=meters;}
    double getElevationOffset() const { return m_elevationOffset; }
+
+   /**
+    * @brief Gets the elevation database for a given point.
+    * @param gpt
+    * @return ossimRefPtr<ossimElevationDatabase> which can hold null pointer
+    * if there is no coverage for the point.
+    */
+   ossimRefPtr<ossimElevationDatabase> getElevationDatabaseForPoint(
+      const ossimGpt& gpt);
+
+   /**
+    * @brief Gets the elevation cell handler for a given point.
+    * @param gpt
+    * @return ossimRefPtr<ossimElevCellHandler> which can hold a null pointer
+    * if there is no coverage for the point OR the underlying elevation
+    * database is not cell based, e.g. ossimTiledElevationDatabase.
+    */
+   ossimRefPtr<ossimElevCellHandler> getCellForPoint(const ossimGpt& gpt);
+
+   /**
+    * @brief Gets the elevation cell filename for a given point.
+    * @param gpt
+    * @param file Initialized by this. Can be empty if there is no coverage
+    * for the point OR the underlying elevation data base is not cell based,
+    * e.g. ossimTiledElevationDatabase.
+    */
+   void getCellFilenameForPoint( const ossimGpt& gpt, ossimFilename& file );
    
    void getOpenCellList(std::vector<ossimFilename>& list) const;
 

--- a/src/elevation/ossimElevManager.cpp
+++ b/src/elevation/ossimElevManager.cpp
@@ -1,9 +1,7 @@
 //**************************************************************************
 // FILE: ossimElevManager.cpp
 //
-// License:  LGPL
-// 
-// See LICENSE.txt file in the top level directory for more details.
+// License: MIT
 //
 // DESCRIPTION:
 //   Contains implementation of class ossimElevManager. This object 
@@ -19,12 +17,13 @@
 //              Initial coding.
 //<
 //**************************************************************************
-// $Id: ossimElevManager.cpp 23641 2015-12-02 20:32:06Z dburken $
+// $Id$
 
 #include <ossim/elevation/ossimElevManager.h>
 #include <ossim/base/ossimEnvironmentUtility.h>
 #include <ossim/elevation/ossimElevationCellDatabase.h>
 #include <ossim/base/ossimDirectory.h>
+#include <ossim/base/ossimFilename.h>
 #include <ossim/base/ossimTrace.h>
 #include <ossim/base/ossimGeoidManager.h>
 #include <ossim/elevation/ossimElevationDatabaseRegistry.h>
@@ -246,6 +245,73 @@ bool ossimElevManager::loadElevationPath(const ossimFilename& path, bool set_as_
    }
    
    return result;
+}
+
+ossimRefPtr<ossimElevationDatabase> ossimElevManager::getElevationDatabaseForPoint(
+   const ossimGpt& gpt )
+{
+   ossimRefPtr<ossimElevationDatabase> db = 0;
+
+   if ( m_dbRoundRobin.size() )
+   {
+      // "m_dbRoundRobin[0]" is a std::vector<ossimRefPtr<ossimElevationDatabase> >
+      const auto& cv = m_dbRoundRobin[0];
+      for ( auto&& i : cv )
+      {
+         if ( i.valid() )
+         {
+            if ( i->pointHasCoverage( gpt ) )
+            {
+               db = i;
+               break;
+            }
+         }
+      }
+   }
+
+   return db;
+}
+
+ossimRefPtr<ossimElevCellHandler> ossimElevManager::getCellForPoint( const ossimGpt& gpt )
+{
+   ossimRefPtr<ossimElevCellHandler> cell = 0;
+
+   if ( m_dbRoundRobin.size() )
+   {
+      // "elevDbList" is a std::vector<ossimRefPtr<ossimElevationDatabase> >
+      ElevationDatabaseListType elevDbList = m_dbRoundRobin[0];
+      for ( auto&& i : elevDbList )
+      {
+         if ( i.valid() )
+         {
+            if ( i->pointHasCoverage( gpt ) )
+            {
+               // See if it's a cell based db.
+               ossimElevationCellDatabase* cellDb =
+                  dynamic_cast<ossimElevationCellDatabase*>( i.get() );
+               if ( cellDb )
+               {
+                  cell = cellDb->getOrCreateCellHandler( gpt );
+                  if ( cell )
+                  {
+                     break;
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   return cell;
+}
+
+void ossimElevManager::getCellFilenameForPoint(const ossimGpt& gpt, ossimFilename& file)
+{
+   ossimRefPtr<ossimElevCellHandler> elevCell = getCellForPoint( gpt );
+   if ( elevCell.valid() )
+   {
+      file = elevCell->getFilename();
+   }
 }
 
 void ossimElevManager::getOpenCellList(std::vector<ossimFilename>& list) const

--- a/src/util/ossimInfo.cpp
+++ b/src/util/ossimInfo.cpp
@@ -2973,6 +2973,53 @@ std::ostream& ossimInfo::outputHeight(const ossimGpt& gpt, std::ostream& out) co
 {
    // Capture the original flags.
    std::ios_base::fmtflags f = out.flags();
+   
+   // Handle wrap conditions.
+   ossimGpt copyGpt = gpt;
+   copyGpt.wrap();
+
+   ossim_float64 hgtAboveMsl = ossim::nan();
+   ossim_float64 hgtAboveEllipsoid = ossim::nan();
+   ossim_float64 geoidOffset = ossim::nan();
+   std::string geoidName = "not_found";
+   
+   ossimFilename cellFilename;
+   ossimElevManager::instance()->getCellFilenameForPoint( copyGpt, cellFilename );
+   if ( cellFilename.empty() )
+   {
+      cellFilename = "not_found";
+   }
+   
+   ossimRefPtr<ossimElevationDatabase> db =
+      ossimElevManager::instance()->getElevationDatabaseForPoint( copyGpt );
+   if ( db.valid() )
+   {
+      hgtAboveMsl = db->getHeightAboveMSL(copyGpt);
+      hgtAboveEllipsoid = db->getHeightAboveEllipsoid(copyGpt);
+      ossimGeoid* geoid = db->getGeoid();
+      if ( geoid )
+      {
+         geoidOffset = geoid->offsetFromEllipsoid(copyGpt);
+         geoidName = geoid->getShortName().string();
+      }
+   }
+
+   out << "elevation.info.cell: " << cellFilename
+       << "\nelevation.info.gpt: " << copyGpt.toString()
+       << "\nelevation.info.geoid_name: " << geoidName
+       << "\nelevation.info.geoid_offset: " << std::setprecision(15) << geoidOffset
+       << "\nelevation.info.height_above_msl: " << hgtAboveMsl
+       << "\nelevation.info.height_above_ellipsoid: " << hgtAboveEllipsoid
+       << "\n";
+
+   // Reset flags.
+   out.setf(f);
+
+   return out;
+   
+#if 0
+   // Capture the original flags.
+   std::ios_base::fmtflags f = out.flags();
 
    // Handle wrap conditions.
    ossimGpt copyGpt = gpt;
@@ -3047,6 +3094,7 @@ std::ostream& ossimInfo::outputHeight(const ossimGpt& gpt, std::ostream& out) co
    out.setf(f);
 
    return out;
+#endif
 }
 
 void ossimInfo::printExtensions() const


### PR DESCRIPTION
Garrett, This will break any ossim-batch-test that does an "ossim-info --height". Old code could potentially give you the wrong geoid offset, i.e. use the wrong geoid from the top of the geoid registry. I know you could just do HOE-HML to get that but also wanted to see the geoid name the database was using. New output looks like this:

$ ossim-info --height 27.84 -80.55
elevation.info.cell: /data1/elevation/srtm/1arc/N27W081.hgt
elevation.info.gpt: (27.84,-80.55,0,WGE)
elevation.info.geoid_name: geoid1996
elevation.info.geoid_offset: -29.4277200012207
elevation.info.height_above_msl: 12.0000000000006
elevation.info.height_above_ellipsoid: -17.4277200012201
