### PR TITLE
BlackSky and SkySat use the Quickbird sensor model but their external…

### DIFF
--- a/src/projection/ossimQuickbirdRpcModel.cpp
+++ b/src/projection/ossimQuickbirdRpcModel.cpp
@@ -313,6 +313,24 @@ bool ossimQuickbirdRpcModel::parseRpcData(const ossimFilename &base_name)
       rpcFile.setExtension("XML");
       if (findSupportFile(rpcFile)) break;
 
+      // SkySat or BlackSky images - START
+      ossimFilename foo1 = rpcFile.noExtension().append( "_rpc.txt" );
+
+      if (findSupportFile(foo1)) {
+         // std::cout << "HERE: Found BlackSky" << std::endl;
+         rpcFile = foo1;
+         break;
+      }
+
+      ossimFilename foo2 = rpcFile.noExtension().append( "_RPC.TXT" );
+
+      if (findSupportFile(foo2)) {
+         // std::cout << "HERE: Found SkySat" << std::endl;
+         rpcFile = foo2;
+         break;
+      }
+      // SkySat or BlackSky images - END
+
       return false;
    }
 
@@ -320,9 +338,11 @@ bool ossimQuickbirdRpcModel::parseRpcData(const ossimFilename &base_name)
    m_qbRpcHeader = std::make_shared<ossimQuickbirdRpcHeader>();
    if (!m_qbRpcHeader->open(rpcFile))
    {
+      // std::cout << "HERE: Cannot Open: " << rpcFile << std::endl;
       m_qbRpcHeader = 0;
       return false;
    }
+
 
    if (m_qbRpcHeader->isAPolynomial())
       thePolyType = A;

--- a/src/projection/ossimQuickbirdRpcModel.cpp
+++ b/src/projection/ossimQuickbirdRpcModel.cpp
@@ -314,19 +314,19 @@ bool ossimQuickbirdRpcModel::parseRpcData(const ossimFilename &base_name)
       if (findSupportFile(rpcFile)) break;
 
       // SkySat or BlackSky images - START
-      ossimFilename foo1 = rpcFile.noExtension().append( "_rpc.txt" );
+      ossimFilename blackSkyRPC = rpcFile.noExtension().append( "_rpc.txt" );
 
-      if (findSupportFile(foo1)) {
+      if (findSupportFile(blackSkyRPC)) {
          // std::cout << "HERE: Found BlackSky" << std::endl;
-         rpcFile = foo1;
+         rpcFile = blackSkyRPC;
          break;
       }
 
-      ossimFilename foo2 = rpcFile.noExtension().append( "_RPC.TXT" );
+      ossimFilename skySatRPC = rpcFile.before("_file_format").append( "_RPC.TXT" );
 
-      if (findSupportFile(foo2)) {
+      if (findSupportFile(skySatRPC)) {
          // std::cout << "HERE: Found SkySat" << std::endl;
-         rpcFile = foo2;
+         rpcFile = skySatRPC;
          break;
       }
       // SkySat or BlackSky images - END

--- a/src/support_data/ossimQuickbirdRpcHeader.cpp
+++ b/src/support_data/ossimQuickbirdRpcHeader.cpp
@@ -89,8 +89,11 @@ bool ossimQuickbirdRpcHeader::open(const ossimFilename& file)
    ossimString line = test;
    line = line.upcase();
    
+   // std::cout << "HERE: parse" << std::endl;
+
    if(parseNameValue(line))
-   {
+   {      
+
       theErrorStatus = ossimErrorCodes::OSSIM_OK;
       getline(in, line);
       while((in)&&(theErrorStatus == ossimErrorCodes::OSSIM_OK))
@@ -373,6 +376,103 @@ bool ossimQuickbirdRpcHeader::parseNameValue(const ossimString& line)
    else if(lineCopy.contains("END"))
    {
    }
+   // SkySat or BlackSky images - START
+   else if(lineCopy.contains("HEIGHT_OFF"))
+   {
+      lineCopy = lineCopy.after(":");
+      theHeightOffset = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("HEIGHT_SCALE"))
+   {
+      lineCopy = lineCopy.after(":");
+      theHeightScale = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LAT_OFF"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLatOffset = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LAT_SCALE"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLatScale = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LINE_OFF"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLineOffset = lineCopy.before("\n").toInt();
+   }
+   else if(lineCopy.contains("LINE_SCALE"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLineScale = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LONG_OFF"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLonOffset = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LONG_SCALE"))
+   {
+      lineCopy = lineCopy.after(":");
+      theLonScale = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("SAMP_OFF"))
+   {
+      lineCopy = lineCopy.after(":");
+      theSampOffset = lineCopy.before("\n").toInt();
+   }
+   else if(lineCopy.contains("SAMP_SCALE"))
+   {
+      lineCopy = lineCopy.after(":");
+      theSampScale = lineCopy.before("\n").toDouble();
+   }
+   else if(lineCopy.contains("LINE_DEN_COEFF"))
+   {
+      ossimString label = lineCopy.before(":");
+      int index = label.explode("_").back().toInt() - 1;
+      double coeff = lineCopy.after(":").before("\n").toDouble();
+
+      // std::cout << "HERE: " << label.substr(0, label.find_last_of('_')) << "(" << index << ")" << "=" << coeff << std::endl;
+
+      //theLineDenCoeff[index] = coeff;
+      theLineDenCoeff.push_back(coeff);
+
+   }
+   else if(lineCopy.contains("LINE_NUM_COEFF"))
+   {
+      ossimString label = lineCopy.before(":");
+      int index = label.explode("_").back().toInt() - 1;
+      double coeff = lineCopy.after(":").before("\n").toDouble();
+
+      // std::cout << "HERE: " << label.substr(0, label.find_last_of('_')) << "(" << index << ")" << "=" << coeff << std::endl;
+
+      // theLineNumCoeff[index] = coeff;
+      theLineNumCoeff.push_back(coeff);
+   }
+   else if(lineCopy.contains("SAMP_DEN_COEFF"))
+   {
+      ossimString label = lineCopy.before(":");
+      int index = label.explode("_").back().toInt() - 1;
+      double coeff = lineCopy.after(":").before("\n").toDouble();
+
+      // std::cout << "HERE: " << label.substr(0, label.find_last_of('_')) << "(" << index << ")" << "=" << coeff << std::endl;
+
+      // theSampDenCoeff[index] = coeff;
+      theSampDenCoeff.push_back(coeff);
+   }
+   else if(lineCopy.contains("SAMP_NUM_COEFF"))
+   {
+      ossimString label = lineCopy.before(":");
+      int index = label.explode("_").back().toInt() - 1;
+      double coeff = lineCopy.after(":").before("\n").toDouble();
+
+      // std::cout << "HERE: " << label.substr(0, label.find_last_of('_')) << "(" << index << ")" << "=" << coeff << std::endl;
+
+      // theSampNumCoeff[index] = coeff;
+      theSampNumCoeff.push_back(coeff);
+   }
+   // SkySat or BlackSky images - END
    else
    {
       result = false;


### PR DESCRIPTION
… file

format is not in the Quickbird specification.   Modified the parser to support
this.   The external files have _rpc.txt (or _RPC.TXT) suffix appended to the
base filenmae of the image.  The following components where parsed from the
external RPC file:

HEIGHT_OFF
HEIGHT_SCALE:
LAT_OFF:
LAT_SCALE:
LINE_DEN_COEFF_10:
LINE_DEN_COEFF_11:
LINE_DEN_COEFF_12:
LINE_DEN_COEFF_13:
LINE_DEN_COEFF_14:
LINE_DEN_COEFF_15:
LINE_DEN_COEFF_16:
LINE_DEN_COEFF_17:
LINE_DEN_COEFF_18:
LINE_DEN_COEFF_19:
LINE_DEN_COEFF_1:
LINE_DEN_COEFF_20:
LINE_DEN_COEFF_2:
LINE_DEN_COEFF_3:
LINE_DEN_COEFF_4:
LINE_DEN_COEFF_5:
LINE_DEN_COEFF_6:
LINE_DEN_COEFF_7:
LINE_DEN_COEFF_8:
LINE_DEN_COEFF_9:
LINE_NUM_COEFF_10:
LINE_NUM_COEFF_11:
LINE_NUM_COEFF_12:
LINE_NUM_COEFF_13:
LINE_NUM_COEFF_14:
LINE_NUM_COEFF_15:
LINE_NUM_COEFF_16:
LINE_NUM_COEFF_17:
LINE_NUM_COEFF_18:
LINE_NUM_COEFF_19:
LINE_NUM_COEFF_1:
LINE_NUM_COEFF_20:
LINE_NUM_COEFF_2:
LINE_NUM_COEFF_3:
LINE_NUM_COEFF_4:
LINE_NUM_COEFF_5:
LINE_NUM_COEFF_6:
LINE_NUM_COEFF_7:
LINE_NUM_COEFF_8:
LINE_NUM_COEFF_9:
LINE_OFF:
LINE_SCALE:
LONG_OFF:
LONG_SCALE:
SAMP_DEN_COEFF_10:
SAMP_DEN_COEFF_11:
SAMP_DEN_COEFF_12:
SAMP_DEN_COEFF_13:
SAMP_DEN_COEFF_14:
SAMP_DEN_COEFF_15:
SAMP_DEN_COEFF_16:
SAMP_DEN_COEFF_17:
SAMP_DEN_COEFF_18:
SAMP_DEN_COEFF_19:
SAMP_DEN_COEFF_1:
SAMP_DEN_COEFF_20:
SAMP_DEN_COEFF_2:
SAMP_DEN_COEFF_3:
SAMP_DEN_COEFF_4:
SAMP_DEN_COEFF_5:
SAMP_DEN_COEFF_6:
SAMP_DEN_COEFF_7:
SAMP_DEN_COEFF_8:
SAMP_DEN_COEFF_9:
SAMP_NUM_COEFF_10:
SAMP_NUM_COEFF_11:
SAMP_NUM_COEFF_12:
SAMP_NUM_COEFF_13:
SAMP_NUM_COEFF_14:
SAMP_NUM_COEFF_15:
SAMP_NUM_COEFF_16:
SAMP_NUM_COEFF_17:
SAMP_NUM_COEFF_18:
SAMP_NUM_COEFF_19:
SAMP_NUM_COEFF_1:
SAMP_NUM_COEFF_20:
SAMP_NUM_COEFF_2:
SAMP_NUM_COEFF_3:
SAMP_NUM_COEFF_4:
SAMP_NUM_COEFF_5:
SAMP_NUM_COEFF_6:
SAMP_NUM_COEFF_7:
SAMP_NUM_COEFF_8:
SAMP_NUM_COEFF_9:
SAMP_OFF:
SAMP_SCALE: