### PR TITLE
Add Text Segment loading and fix MTIMSA tag.

### DIFF
--- a/include/ossim/support_data/ossimNitfTextHeader.h
+++ b/include/ossim/support_data/ossimNitfTextHeader.h
@@ -20,7 +20,8 @@ public:
    ossimNitfTextHeader(){}
    virtual ~ossimNitfTextHeader(){}
    
-   virtual void parseStream(std::istream &in)=0;
+   virtual void parseStream(std::istream &in, ossim_uint64 textLength)=0;
+   virtual const std::vector<unsigned char> getTextData() const=0;
    
 TYPE_DATA
 };

--- a/include/ossim/support_data/ossimNitfTextHeaderV2_0.h
+++ b/include/ossim/support_data/ossimNitfTextHeaderV2_0.h
@@ -20,8 +20,10 @@ public:
    ossimNitfTextHeaderV2_0();
    virtual ~ossimNitfTextHeaderV2_0(){}
    
-   virtual void parseStream(std::istream &in);
+   virtual void parseStream(std::istream &in, ossim_uint64 textLength);
    virtual std::ostream& print(std::ostream &out)const;
+
+   virtual const std::vector<unsigned char> getTextData() const;
 
 TYPE_DATA
 private:
@@ -138,6 +140,11 @@ private:
     * theExtSubheaderDataLength is not 0
     */
    char theExtSubheaderOverflow[4];
+
+   /*!
+    * This is an n-byte field, where n is found in the file header.
+    */
+   std::vector<unsigned char> theText;
 };
 
 #endif

--- a/include/ossim/support_data/ossimNitfTextHeaderV2_1.h
+++ b/include/ossim/support_data/ossimNitfTextHeaderV2_1.h
@@ -19,7 +19,7 @@ public:
    ossimNitfTextHeaderV2_1();
    virtual ~ossimNitfTextHeaderV2_1();
    
-   virtual void parseStream(std::istream &in);
+   virtual void parseStream(std::istream &in, ossim_uint64 textLength);
    virtual std::ostream& print(std::ostream &out)const;
    
    virtual void writeStream(std::ostream &out);
@@ -30,6 +30,8 @@ public:
    void setControlAndHandling(const ossimString& value);
    void setReleasingInstructions(const ossimString& value);
    void setDeclassificationType(const ossimString& value);
+
+   virtual const std::vector<unsigned char> getTextData() const;
    
    static const ossimString TE_KW;
    static const ossimString TEXTID_KW;
@@ -215,6 +217,11 @@ private:
     * theExtSubheaderDataLength is not 0
     */
    char theExtSubheaderOverflow[4];
+
+   /*!
+    * This is an n-byte field, where n is found in the file header.
+    */
+   std::vector<unsigned char> theText;
    
    TYPE_DATA
 };

--- a/src/support_data/ossimNitfFileHeaderV2_0.cpp
+++ b/src/support_data/ossimNitfFileHeaderV2_0.cpp
@@ -1034,7 +1034,7 @@ ossimNitfTextHeader *ossimNitfFileHeaderV2_0::getNewTextHeader(
    {
       result = allocateTextHeader();
       in.seekg(theTextOffsetList[textNumber].theTextHeaderOffset, std::ios::beg);
-      result->parseStream(in);
+      result->parseStream(in, theNitfTextInfoRecords[textNumber].getImageLength());
    }
    
    return result;

--- a/src/support_data/ossimNitfFileHeaderV2_1.cpp
+++ b/src/support_data/ossimNitfFileHeaderV2_1.cpp
@@ -12,7 +12,7 @@
 // $Id$
 
 #include <ossim/support_data/ossimNitfFileHeaderV2_1.h>
-#include <ossim/support_data/ossimNitfTextHeaderV2_0.h>
+#include <ossim/support_data/ossimNitfTextHeaderV2_1.h>
 #include <ossim/base/ossimString.h>
 #include <ossim/base/ossimColorProperty.h>
 #include <ossim/base/ossimDateProperty.h>
@@ -899,7 +899,7 @@ ossimNitfImageHeader* ossimNitfFileHeaderV2_1::allocateImageHeader()const
 
 ossimNitfTextHeader *ossimNitfFileHeaderV2_1::allocateTextHeader()const
 {
-   return new ossimNitfTextHeaderV2_0;
+   return new ossimNitfTextHeaderV2_1;
 }
 
 ossimNitfDataExtensionSegment* ossimNitfFileHeaderV2_1::allocateDataExtSegment()const
@@ -1349,11 +1349,19 @@ ossimNitfFileHeaderV2_1::getNewLabelHeader(ossim_uint32 /* labelNumber */,
 }
 
 ossimNitfTextHeader*
-ossimNitfFileHeaderV2_1::getNewTextHeader(ossim_uint32 /* textNumber */,
-                                          ossim::istream& /* in */)const
+ossimNitfFileHeaderV2_1::getNewTextHeader(ossim_uint32 textNumber,
+                                          ossim::istream& in)const
 {
-   // Currently not implemented...
    ossimNitfTextHeader *result = 0;
+
+   if ((getNumberOfTextSegments() > 0) &&
+      (textNumber < (ossim_int32)theNitfTextFileInfoRecords.size()) &&
+      (textNumber >= 0))
+   {
+      result = allocateTextHeader();
+      in.seekg(theTextFileOffsetList[textNumber].theTextHeaderOffset, ios::beg);
+      result->parseStream(in, theNitfTextFileInfoRecords[textNumber].getTextLength());
+   }
    
    return result;
 }

--- a/src/support_data/ossimNitfMtimsaTag.cpp
+++ b/src/support_data/ossimNitfMtimsaTag.cpp
@@ -74,9 +74,46 @@ void ossimNitfMtimsaTag::parseStream(std::istream& in)
    in.read((char*)m_dt.data(), bytes); // DTs
 }
 
-void ossimNitfMtimsaTag::writeStream(std::ostream& /* out */)
+void ossimNitfMtimsaTag::writeStream(std::ostream& out)
 {
-   // TODO:
+   // Binary data stored in big endian in file.
+   ossimEndian* endian = 0;
+   if ( ossim::byteOrder() != OSSIM_BIG_ENDIAN )
+   {
+      endian = new ossimEndian();
+   }
+    
+   out.write(m_imageSegIndex, IMAGE_SEG_INDEX_SIZE);
+   out.write(m_geocoordsStatic, GEOCOORDS_STATIC_SIZE);
+   out.write(m_layerId, LAYER_ID_SIZE);
+   out.write(m_cameraSetIndex, CAMERA_SET_INDEX_SIZE);   
+   out.write(m_cameraId, CAMERA_ID_SIZE);
+   out.write(m_timeIntervalIndex, TIME_INTERVAL_INDEX_SIZE);
+   out.write(m_tempBlockIndex, TEMP_BLOCK_INDEX_SIZE);
+   out.write(m_nominalFrameRate, NOMINAL_FRAME_RATE_SIZE);   
+   out.write(m_referenceFrameNum, REFERENCE_FRAME_NUM_SIZE);
+   out.write(m_baseTimestamp, BASE_TIMESTAMP_SIZE);
+
+   // Binary data:
+   ossim_uint64 dtMultiplier = m_dtMultiplier;
+   ossim_uint32 numberFrames = m_numberFrames;
+   ossim_uint32 numberDt = m_numberDt;
+   if (endian)
+   {
+      endian->swap(dtMultiplier);
+      endian->swap(numberFrames);
+      endian->swap(numberDt);
+
+      delete endian;
+      endian = 0;
+   }
+   out.write((char*)&m_dtMultiplier, DT_MULTIPLIER_SIZE);
+   out.write((char*)&m_dtSize, DT_SIZE);
+   out.write((char*)&m_numberFrames, NUMBER_OF_FRAMES_SIZE);
+   out.write((char*)&m_numberDt, NUMBER_DT_SIZE);
+
+   ossim_uint32 bytes = m_numberDt * m_dtSize;
+   out.write((char*)m_dt.data(), bytes); // DTs
 }
 
 void ossimNitfMtimsaTag::clearFields()

--- a/src/support_data/ossimNitfTextHeaderV2_0.cpp
+++ b/src/support_data/ossimNitfTextHeaderV2_0.cpp
@@ -21,7 +21,7 @@ ossimNitfTextHeaderV2_0::ossimNitfTextHeaderV2_0()
    clearFields();
 }
 
-void ossimNitfTextHeaderV2_0::parseStream(std::istream &in)
+void ossimNitfTextHeaderV2_0::parseStream(std::istream &in, ossim_uint64 textLength)
 {
    if(in)
    {
@@ -53,6 +53,8 @@ void ossimNitfTextHeaderV2_0::parseStream(std::istream &in)
          // ignore the data for now
          in.ignore(dataLength - 3);
       }
+      theText.resize(textLength);
+      in.read(reinterpret_cast<char*>(&theText.front()), theText.size());
    }
 }
 
@@ -114,4 +116,9 @@ void ossimNitfTextHeaderV2_0::clearFields()
    theTextFormat[3] = '\0';
    theExtSubheaderDataLength[5] = '\0';
    theExtSubheaderOverflow[3] = '\0';
+}
+
+const std::vector<unsigned char> ossimNitfTextHeaderV2_0::getTextData() const
+{
+   return theText;
 }

--- a/src/support_data/ossimNitfTextHeaderV2_1.cpp
+++ b/src/support_data/ossimNitfTextHeaderV2_1.cpp
@@ -57,7 +57,7 @@ ossimNitfTextHeaderV2_1::~ossimNitfTextHeaderV2_1()
 {
 }
 
-void ossimNitfTextHeaderV2_1::parseStream(std::istream &in)
+void ossimNitfTextHeaderV2_1::parseStream(std::istream &in, ossim_uint64 textLength)
 {
    if(in)
    {
@@ -77,7 +77,7 @@ void ossimNitfTextHeaderV2_1::parseStream(std::istream &in)
       in.read(theTextDeclassificationType, 2);
       in.read(theTextDeclassificationDate, 8);
       in.read(theTextDeclassificationExemption, 4);
-      in.read(theTextSecurityDowngrade, 2);
+      in.read(theTextSecurityDowngrade, 1);
       in.read(theTextSecurityDowngradeDate, 8);
       in.read(theTextClassificationText, 43);        // TSCLTX
       in.read(theTextClassificationAthorityType, 1); // TSCATP
@@ -97,6 +97,8 @@ void ossimNitfTextHeaderV2_1::parseStream(std::istream &in)
          // ignore the data for now
          in.ignore(dataLength - 3);
       }
+      theText.resize(textLength);
+      in.read(reinterpret_cast<char*>(&theText.front()), theText.size());
    }
 }
 
@@ -274,4 +276,9 @@ void ossimNitfTextHeaderV2_1::setReleasingInstructions(const ossimString& value)
 void ossimNitfTextHeaderV2_1::setDeclassificationType(const ossimString& value)
 {
    ossimNitfCommon::setField(theTextDeclassificationType, value, 2);
+}
+
+const std::vector<unsigned char> ossimNitfTextHeaderV2_1::getTextData() const
+{
+   return theText;
 }


### PR DESCRIPTION
Can now load and access text segment data from 2.0 and 2.1 NITFs.
MTIMSA tag had no serializer so it was not possible to access the raw tag data or write to a NITF. This has been added.