### PR TITLE
Support M3 compressed data.

### DIFF
--- a/src/support_data/ossimNitfImageHeaderV2_0.cpp
+++ b/src/support_data/ossimNitfImageHeaderV2_0.cpp
@@ -254,9 +254,7 @@ void ossimNitfImageHeaderV2_0::parseStream(ossim::istream& in)
          }
          delete [] blockRead;
       }
-      if((thePadPixelMaskRecordLength > 0)||
-         (( (getCompressionCode().upcase() == "M3"))&&
-          (thePadPixelMaskRecordLength == 0)))
+      if(thePadPixelMaskRecordLength > 0)
       {
          ossim_uint32 totalNumber = 0;
          if(theImageMode[0] == 'S')

--- a/src/support_data/ossimNitfImageHeaderV2_1.cpp
+++ b/src/support_data/ossimNitfImageHeaderV2_1.cpp
@@ -317,8 +317,7 @@ void ossimNitfImageHeaderV2_1::parseStream(ossim::istream& in, const ossimNitfFi
          }
          delete [] blockRead;
       }
-      if( (thePadPixelMaskRecordLength > 0) ||
-          ( (getCompressionCode().upcase() == "M3") && (thePadPixelMaskRecordLength == 0) ) )
+      if(thePadPixelMaskRecordLength > 0)
       {
          ossim_uint32 totalNumber = 0;
          if(theImageMode[0] == 'S')


### PR DESCRIPTION
M3 data is the same as C3 (jpeg compression) with the addition of
a block mask.  This block mask indicates which blocks are empty
and not included in the file.

Remove faulty assumption that M3 data must have a pad pixel mask
even if the header says the pad pixel mask does not exist.

Remap the block offsets/sizes from masked to absolute so the normal
block lookup procedure works.

Tested on the AFRL Greene 07 dataset.