### PR TITLE
Enable relative filenames in ImageElevationDatabase kwl map

### DIFF
--- a/include/ossim/elevation/ossimImageElevationDatabase.h
+++ b/include/ossim/elevation/ossimImageElevationDatabase.h
@@ -180,7 +180,7 @@ private:
 
       void saveState( ossimKeywordlist& kwl, const std::string& prefix ) const;
 
-      bool loadState(const ossimKeywordlist& kwl, const std::string& prefix ); 
+      bool loadState(const ossimKeywordlist& kwl, const std::string& prefix, const ossimFilename& base );
 
       /** file name */
       ossimFilename m_file;

--- a/src/elevation/ossimImageElevationDatabase.cpp
+++ b/src/elevation/ossimImageElevationDatabase.cpp
@@ -450,7 +450,7 @@ bool ossimImageElevationDatabase::loadMapFromKwl()
             {
                prefix = basePrefix + ossimString::toString( index ).string() + dot;
                ossimImageElevationFileEntry entry;
-               if ( entry.loadState( kwl, prefix ) == true )
+               if ( entry.loadState( kwl, prefix, m_connectionString ) == true )
                {
                   // Add the file.
                   m_entryMap.insert( std::make_pair( m_lastMapKey++, entry ) );
@@ -596,7 +596,7 @@ void ossimImageElevationDatabase::ossimImageElevationFileEntry::saveState(
 }
 
 bool ossimImageElevationDatabase::ossimImageElevationFileEntry::loadState(
-   const ossimKeywordlist& kwl, const std::string& prefix )
+   const ossimKeywordlist& kwl, const std::string& prefix, const ossimFilename& connectionString )
 {
    bool result = false;
    std::string key = ossimKeywordNames::FILE_KW;
@@ -604,6 +604,11 @@ bool ossimImageElevationDatabase::ossimImageElevationFileEntry::loadState(
    if ( value.size() )
    {
       m_file = value;
+      // enable paths relative to connectionString
+      if ( m_file[0] == '.' )
+      {
+         m_file = connectionString.dirCat( m_file );
+      }
 
       key = "grect";
       value = kwl.findKey( prefix, key );


### PR DESCRIPTION
The file map is a great addition, but it's not as flexible as it could be. I'm interested in hearing opinions on enabling relative paths in the file map. This allows for preexisting maps to be modified to work in environments where centralized elevation data may be mounted in different locations. Relative paths are a nice feature of VRTs, but I've been experiencing projection issues when doing elevation queries (#289 but I haven't had the opportunity to document the issue on the dev branch, and it's most likely an issue with the gdal plugin, not ossim core).

In order to sidestep potential issues with Windows, a file entry is only appended to connectionString if it starts with a period (instead of a non-slash).

The current patch works and _does not change default behavior_, but the addition of `connectionString` to `ossimImageElevationDatabase::ossimImageElevationFileEntry::loadState` may not be preferred. Doing it in `loadMapFromKwl` feels better, but the way initialization is offloaded to `loadState` prevents that.