### PR TITLE
Added Clang-specific diagnostic guards and broadened use of override …

### DIFF
--- a/apps/ossim-mosaic/ossim-mosaic.cpp
+++ b/apps/ossim-mosaic/ossim-mosaic.cpp
@@ -7,6 +7,7 @@
 //
 //*******************************************************************
 //  $Id: mosaic.cpp 13312 2008-07-27 01:26:52Z gpotts $
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 using namespace std;
@@ -42,6 +43,7 @@ using namespace std;
 #include <ossim/base/ossimObjectFactoryRegistry.h>
 #include <ossim/base/ossimCommon.h>
 #include <ossim/base/ossimRtti.h>
+#include <ossim/base/ossimVisitor.h>
 
 static ossimTrace traceDebug(ossimString("mosaic:main"));
 
@@ -101,7 +103,14 @@ ossimMapProjection* buildProductProjection(const ossimKeywordlist& kwl,
       }
       else
       {
-         source = imageChain->findFirstObjectOfType(STATIC_TYPE_INFO(ossimImageHandler));
+         ossimTypeIdVisitor visitor(STATIC_TYPE_INFO(ossimImageHandler), true,
+                                    ossimVisitor::VISIT_INPUTS | ossimVisitor::VISIT_CHILDREN);
+         imageChain->accept(visitor);
+         ossimCollectionVisitor::ListRef& collection = visitor.getObjects();
+         if (!collection.empty())
+         {
+            source = PTR_CAST(ossimConnectableObject, collection.front().get());
+         }
       }
 
       if(source)
@@ -145,7 +154,17 @@ bool buildRenderers(const ossimKeywordlist& specFile,
       ossimImageChain* imageChain = PTR_CAST(ossimImageChain, imageSources[index].get());
       if(imageChain)
       {
-         ossimConnectableObject* source = imageChain->findFirstObjectOfType(STATIC_TYPE_INFO(ossimImageHandler));
+         ossimConnectableObject* source = 0;
+         {
+            ossimTypeIdVisitor visitor(STATIC_TYPE_INFO(ossimImageHandler), true,
+                                       ossimVisitor::VISIT_INPUTS | ossimVisitor::VISIT_CHILDREN);
+            imageChain->accept(visitor);
+            ossimCollectionVisitor::ListRef& collection = visitor.getObjects();
+            if (!collection.empty())
+            {
+               source = PTR_CAST(ossimConnectableObject, collection.front().get());
+            }
+         }
 
          if(source)
          {
@@ -445,7 +464,7 @@ int main(int argc, char *argv[])
 		   if(!productProjection)
 		   {
 		      cerr << "unable to create product projection" << endl;
-		      return false;
+		      return EXIT_FAILURE;
 		   }
 		   
 		   // now let's build up the renderers
@@ -511,7 +530,7 @@ int main(int argc, char *argv[])
 							<< "\nCould not execute writer!"
 							<< "\nExiting..."
 							<< std::endl;
-						return 1;
+						return EXIT_FAILURE;
 					}
 		            //}
 		            writer->removeListener(&listener);
@@ -524,7 +543,7 @@ int main(int argc, char *argv[])
 		   }
 		   else
 		   {
-		      return 1;
+		      return EXIT_FAILURE;
 		   }
 		}
    }
@@ -535,5 +554,5 @@ int main(int argc, char *argv[])
          ossimNotify(ossimNotifyLevel_INFO));
    }
 
-   return 0;
+   return EXIT_SUCCESS;
 }

--- a/apps/ossim-plot-histo/ossim-plot-histo.cpp
+++ b/apps/ossim-plot-histo/ossim-plot-histo.cpp
@@ -18,6 +18,8 @@
 #include <fstream>
 #include <vector>
 #include <algorithm>
+#include <inttypes.h>
+#include <sstream>
 #include <ossim/imaging/ossimImageHandlerRegistry.h>
 #include <ossim/imaging/ossimImageHandler.h>
 #include <ossim/imaging/ossimImageData.h>
@@ -95,7 +97,7 @@ void plotHistogram(const ossimFilename& histoFile, const ossimString& plotWith,
    const ossim_int64* y = histogram->GetCounts();
    for (int i=0; i<numBins; ++i)
    {
-      fprintf(gnuplotPipe, "%f %i \n", x[i], y[i]);
+      fprintf(gnuplotPipe, "%f %" PRIi64 " \n", x[i], y[i]);
    }
    fprintf(gnuplotPipe, "e");
    fclose(gnuplotPipe);

--- a/apps/ossim-swapbytes/ossim-swapbytes.cpp
+++ b/apps/ossim-swapbytes/ossim-swapbytes.cpp
@@ -35,8 +35,8 @@ int main(int argc, char** argv)
 {
    enum
    {
-      OK,
-      ERROR
+      OK    = EXIT_SUCCESS,
+      ERROR = EXIT_FAILURE
    };
    ossimString tempString;
    ossimArgumentParser argumentParser(&argc, argv);
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
    {
       cerr << "swapbytes" << " ERROR:\n"
            << "Cannot open:  " << argv[1] << endl;
-      return false;
+      return EXIT_FAILURE;
    }
 
    // Output stream to new file.
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
    {
       cerr << "swapbytes" << " ERROR:\n"
            << "Cannot open:  " << argv[2] << endl;
-      return false;
+      return EXIT_FAILURE;
    }
 
    //***

--- a/include/ossim/base/ossim2dTo2dCompositeTransform.h
+++ b/include/ossim/base/ossim2dTo2dCompositeTransform.h
@@ -25,7 +25,7 @@ public:
    ossim2dTo2dCompositeTransform(const CompositeTransformList& compositeTransformList = CompositeTransformList());
    ossim2dTo2dCompositeTransform(const ossim2dTo2dCompositeTransform& rhs);
    virtual ~ossim2dTo2dCompositeTransform();
-   virtual ossimObject* dup()const;
+   ossimObject* dup()const override;
 
 
    void add(ossimRefPtr<ossim2dTo2dTransform> transform);
@@ -38,27 +38,27 @@ public:
     * the forward transform.  The output of the previous is used as the input to the next
     * transform.
     */
-   virtual void forward(const ossimDpt& input,
-                        ossimDpt& output) const;
+   void forward(const ossimDpt& input,
+                        ossimDpt& output) const override;
 
 
    /**
     * will call the forward method with 2 arguments
     */
-   virtual void forward(ossimDpt&  /* modify_this */) const;
+   void forward(ossimDpt&  /* modify_this */) const override;
    
    /**
     * Will iterate through the transformation list in reverse order from
     * n-1 ... 0 calling the inverse for each one.  The output is passed in as input
     * to the next transform.
     */
-   virtual void inverse(const ossimDpt& input,
-                        ossimDpt&       output) const;
+   void inverse(const ossimDpt& input,
+                        ossimDpt&       output) const override;
    
    /**
     * will call the inverse method with 2 arguments
     */
-   virtual void inverse(ossimDpt&  /* modify_this */) const;
+   void inverse(ossimDpt&  /* modify_this */) const override;
    
    /**
     * Pass equality to the parent
@@ -81,13 +81,13 @@ public:
     * <prefix>.object<n-1>
     * 
     */
-   virtual bool saveState(ossimKeywordlist& kwl, const char* prefix=0)const;
+   bool saveState(ossimKeywordlist& kwl, const char* prefix=0)const override;
 
    /**
     * Will laod the state of the object.  Note, it will clear the list and then add
     * all prefix found from the save state.
     */
-   virtual bool loadState(const ossimKeywordlist& kwl, const char* prefix=0);
+   bool loadState(const ossimKeywordlist& kwl, const char* prefix=0) override;
 
 protected:
    /**

--- a/include/ossim/base/ossim2dTo2dTransformRegistry.h
+++ b/include/ossim/base/ossim2dTo2dTransformRegistry.h
@@ -28,7 +28,7 @@ public:
    /*!
     * Creates an object given a type name.
     */
-   virtual ossimObject* createObject(const ossimString& typeName)const
+   ossimObject* createObject(const ossimString& typeName)const override
    {
       return createObjectFromRegistry(typeName);
    }
@@ -36,15 +36,15 @@ public:
    /*!
     * Creates and object given a keyword list.
     */
-   virtual ossimObject* createObject(const ossimKeywordlist& kwl,
-                                     const char* prefix=0)const
+   ossimObject* createObject(const ossimKeywordlist& kwl,
+                                     const char* prefix=0)const override
    {
       return createObjectFromRegistry(kwl, prefix);
    }
    /*!
     * Creates an object given a type name.
     */
-   virtual ossim2dTo2dTransform* createTransform(const ossimString& typeName)const
+   ossim2dTo2dTransform* createTransform(const ossimString& typeName)const
    {
       return createNativeObjectFromRegistry(typeName);
    }
@@ -52,7 +52,7 @@ public:
    /*!
     * Creates and object given a keyword list.
     */
-   virtual ossim2dTo2dTransform* createTransform(const ossimKeywordlist& kwl,
+   ossim2dTo2dTransform* createTransform(const ossimKeywordlist& kwl,
                                                  const char* prefix=0)const
    {
       return createNativeObjectFromRegistry(kwl, prefix);
@@ -63,7 +63,7 @@ public:
     * This is the name used to construct the objects dynamially and this
     * name must be unique.
     */
-   virtual void getTypeNameList(std::vector<ossimString>& typeList)const
+   void getTypeNameList(std::vector<ossimString>& typeList)const override
    {
       getAllTypeNamesFromRegistry(typeList);
    }

--- a/include/ossim/base/ossimDms.h
+++ b/include/ossim/base/ossimDms.h
@@ -15,6 +15,7 @@
 
 #include <ossim/base/ossimConstants.h> /* for OSSIM_DLL macro */
 #include <ossim/base/ossimString.h>
+#include <cstddef>
 
 class OSSIM_DLL ossimDms
 {
@@ -157,7 +158,7 @@ private:
     *	the number of d's or m's or s's seen in the group
     *	just parsed.
     */
-   void setup_printf(int ival, char *fmt)const;
+   void setup_printf(int ival, char *fmt, std::size_t fmtSize)const;
 
    /**
     * function set_default						*

--- a/include/ossim/base/ossimReferenced.h
+++ b/include/ossim/base/ossimReferenced.h
@@ -68,7 +68,7 @@ class OSSIMDLLEXPORT ossimReferenced
    
    
  protected:
-   virtual ~ossimReferenced();
+  virtual ~ossimReferenced();
 
  private:
     mutable std::atomic_int      m_refCount;

--- a/include/ossim/base/ossimRtti.h
+++ b/include/ossim/base/ossimRtti.h
@@ -336,7 +336,16 @@ inline RTTIdyntypeid::~RTTIdyntypeid()
 // Definition of TYPE_DATA for a RTTI-class: introduces one static RTTITypeinfo data-member
 // and a couple of virtuals.
 
+#ifdef __clang__
+#  define OSSIM_CLANG_OVERRIDE_WARN_PUSH _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Winconsistent-missing-override\"")
+#  define OSSIM_CLANG_OVERRIDE_WARN_POP _Pragma("clang diagnostic pop")
+#else
+#  define OSSIM_CLANG_OVERRIDE_WARN_PUSH
+#  define OSSIM_CLANG_OVERRIDE_WARN_POP
+#endif
+
 #define TYPE_DATA			 		          \
+   OSSIM_CLANG_OVERRIDE_WARN_PUSH                       \
 	protected:					          \
 	   static  const  RTTITypeinfo RTTI_obj; 		  \
 	   static  void*  RTTI_scast(int,void*);	          \
@@ -345,8 +354,8 @@ inline RTTIdyntypeid::~RTTIdyntypeid()
 	   virtual RTTItypeid RTTI_vinfo() const { return &RTTI_obj; }\
 	   static  RTTItypeid RTTI_sinfo()	 { return &RTTI_obj; }\
 	   virtual void*  RTTI_cast(RTTItypeid);\
-	   virtual const void*  RTTI_cast(RTTItypeid)const;
-	
+	   virtual const void*  RTTI_cast(RTTItypeid)const;\
+	   OSSIM_CLANG_OVERRIDE_WARN_POP
 
 
 // Definition of auxiliary data-structs supporting RTTI for a class: defines the static RTTITypeinfo

--- a/include/ossim/matrix/newmat.h
+++ b/include/ossim/matrix/newmat.h
@@ -1569,7 +1569,7 @@ class OSSIM_DLL MatrixInput // for reading a list of values into a matrix
 public:
    MatrixInput(const MatrixInput& mi) : n(mi.n), r(mi.r) {}
    MatrixInput(int nx, Real* rx) : n(nx), r(rx) {}
-   ~MatrixInput();
+   ~MatrixInput() noexcept(false);
    MatrixInput operator<<(Real);
    MatrixInput operator<<(int f);
    friend class GeneralMatrix;
@@ -1798,7 +1798,6 @@ inline MatrixInput GetSubMatrix::operator<<(int f) { return *this << (Real)f; }
 // body file: newmatex.cpp
 // body file: bandmat.cpp
 // body file: submat.cpp
-
 
 
 

--- a/include/ossim/projection/ossimLlxyProjection.h
+++ b/include/ossim/projection/ossimLlxyProjection.h
@@ -29,14 +29,14 @@ public:
                        double latSpacing,  // decimal degrees
                        double lonSpacing);
    
-   virtual ~ossimLlxyProjection();
-   
-   virtual ossimObject *dup()const;
-   
-   virtual bool isGeographic()const;
-   
-   virtual ossimDpt forward(const ossimGpt &worldPoint) const;
-   virtual ossimGpt inverse(const ossimDpt &projectedPoint) const;
+   ~ossimLlxyProjection() override;
+
+   ossimObject *dup()const override;
+
+   bool isGeographic()const override;
+
+   ossimDpt forward(const ossimGpt &worldPoint) const override;
+   ossimGpt inverse(const ossimDpt &projectedPoint) const override;
    
    /*!
     *  METHOD:  getLatSpacing() 
@@ -66,36 +66,36 @@ public:
     *  METHOD: worldToLineSample()
     * Performs the forward projection from ground point to line, sample.
     */
-   virtual void worldToLineSample(const ossimGpt& worldPoint,
-                                  ossimDpt&       lineSampPt) const;
+   void worldToLineSample(const ossimGpt& worldPoint,
+                          ossimDpt&       lineSampPt) const override;
 
    /*!
     * Performs the inverse projection from line, sample to ground (world):
     */
-   virtual void lineSampleHeightToWorld(const ossimDpt& lineSampPt,
-                                        const double&  hgtEllipsoid,
-                                        ossimGpt&       worldPt) const;
+   void lineSampleHeightToWorld(const ossimDpt& lineSampPt,
+                                const double&  hgtEllipsoid,
+                                ossimGpt&       worldPt) const override;
    
    /*!
     * Method to save the state of an object to a keyword list.
     * Return true if ok or false on error.
     */
-   virtual bool saveState(ossimKeywordlist& kwl,
-                          const char* prefix=0)const;
+   bool saveState(ossimKeywordlist& kwl,
+                  const char* prefix=0)const override;
 
    /*!
     * Method to the load (recreate) the state of an object from a keyword
     * list.  Return true if ok or false on error.
     */
-   virtual bool loadState(const ossimKeywordlist& kwl,
-                          const char* prefix=0);
+   bool loadState(const ossimKeywordlist& kwl,
+                  const char* prefix=0) override;
 
-   virtual std::ostream& print(std::ostream& out) const;
+   std::ostream& print(std::ostream& out) const override;
 
-   virtual bool operator==(const ossimProjection& projection) const;
+   bool operator==(const ossimProjection& projection) const override;
 
   //   virtual ossimDpt getMetersPerPixel() const;
-   virtual void setMetersPerPixel(const ossimDpt& pt);
+   void setMetersPerPixel(const ossimDpt& pt) override;
    /*!
     * This will go from the ground point and give
     * you an approximate lat and lon per pixel. the Delta Lat

--- a/src/base/ossimConnectableContainer.cpp
+++ b/src/base/ossimConnectableContainer.cpp
@@ -99,6 +99,11 @@ ossimConnectableContainer::~ossimConnectableContainer()
    theChildListener = 0;
 }
 
+#ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 ossimConnectableObject* ossimConnectableContainer::findFirstObjectOfType(const RTTItypeid& typeInfo,
                                                                          bool recurse)
 {
@@ -252,6 +257,10 @@ ossimConnectableObject::ConnectableObjectList ossimConnectableContainer::findAll
    }
    return result;
 }
+
+#ifdef __clang__
+#  pragma clang diagnostic pop
+#endif
 
 ossimConnectableObject* ossimConnectableContainer::findObject(const ossimId& id,
                                                               bool recurse)

--- a/src/base/ossimConnectableObject.cpp
+++ b/src/base/ossimConnectableObject.cpp
@@ -1592,6 +1592,11 @@ const ossimConnectableObject* ossimConnectableObject::getOutput(ossim_uint32 idx
    return 0;
 }
 
+#ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void  ossimConnectableObject::findAllObjectsOfType(ConnectableObjectList& result,
                                                    const RTTItypeid& typeInfo,
                                                    bool recurse)
@@ -1642,6 +1647,10 @@ void ossimConnectableObject::findAllObjectsOfType(ConnectableObjectList& result,
       }
    }
 }
+
+#ifdef __clang__
+#  pragma clang diagnostic pop
+#endif
 
 #if 0
 void ossimConnectableObject::findAllInputsOfType(ConnectableObjectList& result,

--- a/src/base/ossimDms.cpp
+++ b/src/base/ossimDms.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <cstring> /* for strcpy */
 #include <cstdio>
+#include <cstddef>
 #include <iomanip>
 #include <sstream>
 
@@ -478,7 +479,7 @@ ossimString ossimDms::degree_to_string(double degrees,
 {
    char cdegrees[64];
    char str_fmt[10];
-   char *rptr, *fptr, *sptr;
+   char *rptr, *fptr;
    int i, d_s;
    
 /* assign a default format if none is given */
@@ -497,7 +498,6 @@ ossimString ossimDms::degree_to_string(double degrees,
    
    rptr = cdegrees;
    fptr = format;
-   sptr = str_fmt;
    
 /* cycle through characters of the format and plug in values */
    
@@ -528,7 +528,7 @@ ossimString ossimDms::degree_to_string(double degrees,
 	   	while (*fptr == 'd') {
 		   d_s++, fptr++;
 	   	}
-		setup_printf(d_s, sptr);	/* printf's fmt will be %x.xd */
+		setup_printf(d_s, str_fmt, sizeof(str_fmt));	/* printf's fmt will be %x.xd */
 
 		if (theAfterDot == true) {		/* beyond the decimal point */
 		   i = d_s;
@@ -538,7 +538,13 @@ ossimString ossimDms::degree_to_string(double degrees,
 		   theIntDegs = (int)(theDecDegs);
 		 }
 
-		sprintf(rptr, str_fmt, theIntDegs);
+		{
+		   const std::size_t remaining = static_cast<std::size_t>((cdegrees + sizeof(cdegrees)) - rptr);
+		   if (remaining > 0)
+		   {
+		      std::snprintf(rptr, remaining, str_fmt, theIntDegs);
+		   }
+		}
 
 		if (*rptr == '0' && !theAfterDot)	/* remove leading zero */
 		   *rptr = ' ';
@@ -709,8 +715,12 @@ int ossimDms::calc_mins_or_secs(double *dd,
 	   ires = (int)(du) / ufactor;
 	   *dd = (du - (ires * ufactor)) / (double)ufactor;
 	}
-	setup_printf(numunits, str_fmt);
-	sprintf(res, str_fmt, ires);
+	setup_printf(numunits, str_fmt, sizeof(str_fmt));
+	const std::size_t maxLen = static_cast<std::size_t>(numunits) + 1;
+	if (maxLen > 0)
+	{
+	   std::snprintf(res, maxLen, str_fmt, ires);
+	}
         
 	return(numunits);
 }
@@ -724,16 +734,13 @@ int ossimDms::calc_mins_or_secs(double *dd,
  *	just parsed.						*
  ****************************************************************/
 
-void ossimDms::setup_printf(int ival, char *fmt)const
+void ossimDms::setup_printf(int ival, char *fmt, std::size_t fmtSize)const
 {
-	char precis[3];
-	
-	strcpy(fmt, "%");
-	sprintf(precis, "%d", ival);
-	strcat(fmt,precis);
-	strcat(fmt,".");
-	strcat(fmt,precis);
-	strcat(fmt,"d");
+	if (!fmt || fmtSize == 0)
+	{
+	   return;
+	}
+	std::snprintf(fmt, fmtSize, "%%%d.%dd", ival, ival);
 }
 
 /****************************************************************

--- a/src/base/ossimGeoref.cpp
+++ b/src/base/ossimGeoref.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cmath>
 #include <cctype>
+#include <cstddef>
 
 // These are Geotrans defines and code.
 /***************************************************************************/
@@ -221,7 +222,9 @@ void Convert_Minutes_To_String(double minutes,
     minutes = 59.999;
   minutes = minutes * 1000;
   min = Round_GEOREF (minutes/divisor);
-  sprintf (str, "%*.*ld", (int)precision, (int)precision, min);
+  const std::size_t width = static_cast<std::size_t>(precision);
+  const std::size_t bufferSize = width + 1;
+  std::snprintf (str, bufferSize, "%*.*ld", static_cast<int>(precision), static_cast<int>(precision), min);
   if (precision == 1)
     strcat (str, "0");
 } /* END Convert_Minutes_To_String */

--- a/src/base/ossimNotify.cpp
+++ b/src/base/ossimNotify.cpp
@@ -336,11 +336,11 @@ ossimString ossimErrorV(const char *fmt, va_list args )
    char temp[2024];
    if(fmt)
    {
-      vsprintf(temp, fmt, args);
+      std::vsnprintf(temp, sizeof(temp), fmt, args);
    }
    else
    {
-      sprintf(temp,"%s", "");
+      std::snprintf(temp, sizeof(temp), "%s", "");
    }
 
    return temp;

--- a/src/base/ossimViewController.cpp
+++ b/src/base/ossimViewController.cpp
@@ -4,6 +4,7 @@
 #include <ossim/base/ossimListenerManager.h>
 #include <ossim/base/ossimPropertyEvent.h>
 #include <ossim/base/ossimNotifyContext.h>
+#include <ossim/base/ossimVisitor.h>
 #include <vector>
 using namespace std;
 
@@ -65,32 +66,39 @@ bool ossimViewController::propagateView()
    if(inter)
    {
       RTTItypeid typeId = STATIC_TYPE_INFO(ossimViewInterface);
-      ossimConnectableObject::ConnectableObjectList result = inter->findAllObjectsOfType(typeId,
-                                                                           true);
-      if(result.size() > 0)
+      ossimTypeIdVisitor visitor(typeId, false,
+                                 ossimVisitor::VISIT_INPUTS | ossimVisitor::VISIT_CHILDREN);
+      ossimConnectableObject* ownerObj = dynamic_cast<ossimConnectableObject*>(theOwner);
+      if(ownerObj)
       {
-         ossim_uint32 index = 0;
-
-         // first set all views then update all outputs
-         //
-         for(index = 0; index < result.size(); ++index)
+         ownerObj->accept(visitor);
+         ossimCollectionVisitor::ListRef& objects = visitor.getObjects();
+         if(!objects.empty())
          {
-            ossimViewInterface* viewInterface = PTR_CAST(ossimViewInterface, result[index].get());
-
-            if(viewInterface)
+            // first set all views then update all outputs
+            for(ossim_uint32 index = 0; index < objects.size(); ++index)
             {
-               if(!viewInterface->setView(theView.get()))
+               ossimViewInterface* viewInterface = PTR_CAST(ossimViewInterface, objects[index].get());
+
+               if(viewInterface)
                {
-                  returnResult = false;
+                  if(!viewInterface->setView(theView.get()))
+                  {
+                     returnResult = false;
+                  }
                }
             }
-         }
 
-         for(index = 0; index < result.size(); ++index)
-         {
-            ossimPropertyEvent event(result[index].get());
-            result[index]->fireEvent(event);
-            result[index]->propagateEventToOutputs(event);
+            for(ossim_uint32 index = 0; index < objects.size(); ++index)
+            {
+               ossimConnectableObject* obj = PTR_CAST(ossimConnectableObject, objects[index].get());
+               if (obj)
+               {
+                  ossimPropertyEvent event(obj);
+                  obj->fireEvent(event);
+                  obj->propagateEventToOutputs(event);
+               }
+            }
          }
       }
    }

--- a/src/imaging/ossimDdffielddefn.cpp
+++ b/src/imaging/ossimDdffielddefn.cpp
@@ -30,6 +30,8 @@
  */
 
 #include <cstring>
+#include <cstdio>
+#include <cstddef>
 #include <ossim/imaging/ossimIso8211.h>
 #include <ossim/base/ossimNotifyContext.h>
 #include <ossim/base/ossimCplUtil.h>
@@ -232,13 +234,20 @@ int ossimDDFFieldDefn::GenerateDDREntry( char **ppachData,
     (*ppachData)[6] = ' ';
     (*ppachData)[7] = ' ';
     (*ppachData)[8] = ' ';
-    sprintf( *ppachData + 9, "%s%c%s", 
-             _fieldName, OSSIM_DDF_UNIT_TERMINATOR, _arrayDescr );
+    std::snprintf( *ppachData + 9, (*pnLength + 1) - 9, "%s%c%s",
+                   _fieldName, OSSIM_DDF_UNIT_TERMINATOR, _arrayDescr );
 
     if( strlen(_formatControls) > 0 )
-        sprintf( *ppachData + strlen(*ppachData), "%c%s",
-                 OSSIM_DDF_UNIT_TERMINATOR, _formatControls );
-    sprintf( *ppachData + strlen(*ppachData), "%c", OSSIM_DDF_FIELD_TERMINATOR );
+    {
+        const std::size_t offset = strlen(*ppachData);
+        std::snprintf( *ppachData + offset, (*pnLength + 1) - offset, "%c%s",
+                       OSSIM_DDF_UNIT_TERMINATOR, _formatControls );
+    }
+    {
+        const std::size_t offset = strlen(*ppachData);
+        std::snprintf( *ppachData + offset, (*pnLength + 1) - offset, "%c",
+                       OSSIM_DDF_FIELD_TERMINATOR );
+    }
 
     return true;
 }

--- a/src/imaging/ossimDdfmodule.cpp
+++ b/src/imaging/ossimDdfmodule.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <cstring>
+#include <cstdio>
 #include <ossim/imaging/ossimIso8211.h>
 #include <ossim/base/ossimNotifyContext.h>
 #include <ossim/base/ossimCplUtil.h>
@@ -422,19 +423,19 @@ int ossimDDFModule::Create( const char *pszFilename )
 /* -------------------------------------------------------------------- */
     char achLeader[25];
 
-    sprintf( achLeader+0, "%05d", (int) _recLength );
+    std::snprintf( achLeader + 0, sizeof(achLeader) - 0, "%05d", static_cast<int>(_recLength) );
     achLeader[5] = _interchangeLevel;
     achLeader[6] = _leaderIden;
     achLeader[7] = _inlineCodeExtensionIndicator;
     achLeader[8] = _versionNumber;
     achLeader[9] = _appIndicator;
-    sprintf( achLeader+10, "%02d", (int) _fieldControlLength );
-    sprintf( achLeader+12, "%05d", (int) _fieldAreaStart );
+    std::snprintf( achLeader + 10, sizeof(achLeader) - 10, "%02d", static_cast<int>(_fieldControlLength) );
+    std::snprintf( achLeader + 12, sizeof(achLeader) - 12, "%05d", static_cast<int>(_fieldAreaStart) );
     strncpy( achLeader+17, _extendedCharSet, 3 );
-    sprintf( achLeader+20, "%1d", (int) _sizeFieldLength );
-    sprintf( achLeader+21, "%1d", (int) _sizeFieldPos );
+    std::snprintf( achLeader + 20, sizeof(achLeader) - 20, "%1d", static_cast<int>(_sizeFieldLength) );
+    std::snprintf( achLeader + 21, sizeof(achLeader) - 21, "%1d", static_cast<int>(_sizeFieldPos) );
     achLeader[22] = '0';
-    sprintf( achLeader+23, "%1d", (int) _sizeFieldTag );
+    std::snprintf( achLeader + 23, sizeof(achLeader) - 23, "%1d", static_cast<int>(_sizeFieldTag) );
     fwrite( achLeader, 24, 1, fpDDF );
 
 /* -------------------------------------------------------------------- */
@@ -449,9 +450,12 @@ int ossimDDFModule::Create( const char *pszFilename )
         papoFieldDefns[iField]->GenerateDDREntry( NULL, &nLength );
 
         strcpy( achDirEntry, papoFieldDefns[iField]->GetName() );
-        sprintf( achDirEntry + _sizeFieldTag, "%03d", nLength );
-        sprintf( achDirEntry + _sizeFieldTag + _sizeFieldLength, 
-                 "%04d", nOffset );
+        std::snprintf( achDirEntry + _sizeFieldTag,
+                       sizeof(achDirEntry) - _sizeFieldTag,
+                       "%03d", nLength );
+        std::snprintf( achDirEntry + _sizeFieldTag + _sizeFieldLength,
+                       sizeof(achDirEntry) - _sizeFieldTag - _sizeFieldLength,
+                       "%04d", nOffset );
         nOffset += nLength;
 
         fwrite( achDirEntry, 11, 1, fpDDF );

--- a/src/imaging/ossimDdfrecord.cpp
+++ b/src/imaging/ossimDdfrecord.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <cstring>
+#include <cstdio>
 #include <ossim/imaging/ossimIso8211.h>
 #include <ossim/base/ossimNotifyContext.h>
 #include <ossim/base/ossimCplUtil.h>
@@ -191,13 +192,13 @@ int ossimDDFRecord::Write()
 
     memset( szLeader, ' ', nLeaderSize );
 
-    sprintf( szLeader+0, "%05d",
-             static_cast<int>(nDataSize + nLeaderSize) );
+    std::snprintf( szLeader + 0, sizeof(szLeader) - 0,
+                   "%05d", static_cast<int>(nDataSize + nLeaderSize) );
     szLeader[5] = ' ';
     szLeader[6] = 'D';
     
-    sprintf( szLeader + 12, "%05d",
-             static_cast<int>(nFieldOffset + nLeaderSize) );
+    std::snprintf( szLeader + 12, sizeof(szLeader) - 12,
+                   "%05d", static_cast<int>(nFieldOffset + nLeaderSize) );
     szLeader[17] = ' ';
 
     szLeader[20] = (char) ('0' + _sizeFieldLength);
@@ -1463,12 +1464,12 @@ int ossimDDFRecord::ResetDirectory()
         ossimDDFFieldDefn *poDefn = poField->GetFieldDefn();
         char      szFormat[128];
 
-        sprintf( szFormat, "%%%ds%%0%dd%%0%dd", 
-                 _sizeFieldTag, _sizeFieldLength, _sizeFieldPos );
+        std::snprintf( szFormat, sizeof(szFormat), "%%%ds%%0%dd%%0%dd",
+                       _sizeFieldTag, _sizeFieldLength, _sizeFieldPos );
 
-        sprintf( pachData + nEntrySize * iField, szFormat, 
-                 poDefn->GetName(), poField->GetDataSize(),
-                 poField->GetData() - pachData - nFieldOffset );
+        std::snprintf( pachData + nEntrySize * iField, nEntrySize + 1, szFormat,
+                       poDefn->GetName(), poField->GetDataSize(),
+                       poField->GetData() - pachData - nFieldOffset );
     }
 
     pachData[nEntrySize * nFieldCount] = OSSIM_DDF_FIELD_TERMINATOR;

--- a/src/imaging/ossimDdfsubfielddefn.cpp
+++ b/src/imaging/ossimDdfsubfielddefn.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <cstring>
+#include <cstdio>
 #include <ossim/imaging/ossimIso8211.h>
 #include <ossim/base/ossimNotifyContext.h>
 #include <ossim/base/ossimCommon.h>
@@ -861,7 +862,7 @@ int ossimDDFSubfieldDefn::FormatIntValue( char *pachData, int nBytesAvailable,
     int nSize;
     char szWork[30];
 
-    sprintf( szWork, "%d", nNewValue );
+    std::snprintf( szWork, sizeof(szWork), "%d", nNewValue );
 
     if( bIsVariable )
     {
@@ -950,7 +951,7 @@ int ossimDDFSubfieldDefn::FormatFloatValue( char *pachData, int nBytesAvailable,
     int nSize;
     char szWork[120];
 
-    sprintf( szWork, "%.16g", dfNewValue );
+    std::snprintf( szWork, sizeof(szWork), "%.16g", dfNewValue );
 
     if( bIsVariable )
     {

--- a/src/imaging/ossimGeoAnnotationGdBitmapFont.cpp
+++ b/src/imaging/ossimGeoAnnotationGdBitmapFont.cpp
@@ -38,7 +38,9 @@ ossimGeoAnnotationGdBitmapFont::ossimGeoAnnotationGdBitmapFont(const ossimGpt& p
 
 ossimGeoAnnotationGdBitmapFont::ossimGeoAnnotationGdBitmapFont(const ossimGeoAnnotationGdBitmapFont& rhs)
    :ossimGeoAnnotationObject(rhs),
-    theProjectedFont(rhs.theProjectedFont.valid()?(ossimAnnotationGdBitmapFont*)theProjectedFont->dup():(ossimAnnotationGdBitmapFont*)0),
+    theProjectedFont(rhs.theProjectedFont.valid() ?
+                     static_cast<ossimAnnotationGdBitmapFont*>(rhs.theProjectedFont->dup()) :
+                     static_cast<ossimAnnotationGdBitmapFont*>(0)),
     thePosition(rhs.thePosition)
 {
 }

--- a/src/init/ossimInit.cpp
+++ b/src/init/ossimInit.cpp
@@ -85,11 +85,11 @@ ossimString geosErrorV(const char *fmt, va_list args)
    char temp[2024];
    if (fmt)
    {
-      vsprintf(temp, fmt, args);
+      std::vsnprintf(temp, sizeof(temp), fmt, args);
    }
    else
    {
-      sprintf(temp, "%s", "");
+      std::snprintf(temp, sizeof(temp), "%s", "");
    }
 
    return temp;

--- a/src/matrix/newmat5.cpp
+++ b/src/matrix/newmat5.cpp
@@ -431,7 +431,7 @@ MatrixInput GetSubMatrix::operator<<(Real f)
    return MatrixInput(n, r+1);
 }
 
-MatrixInput::~MatrixInput()
+MatrixInput::~MatrixInput() noexcept(false)
 {
    REPORT
    Tracer et("MatrixInput");
@@ -482,4 +482,3 @@ void GeneralMatrix::ReverseElements()
 #ifdef use_namespace
 }
 #endif
-

--- a/src/projection/ossimBngProjection.cpp
+++ b/src/projection/ossimBngProjection.cpp
@@ -14,8 +14,8 @@
 #include <ossim/base/ossimKeywordNames.h>
 #include <ossim/elevation/ossimElevManager.h>
 
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 
 #define BNG_NO_ERROR           0x0000
 #define BNG_LAT_ERROR          0x0001
@@ -43,6 +43,7 @@ static double BNG_Easting = 0.0;
 static double BNG_Northing = 0.0;
 static const char* Airy = "AA";
 static char BNG_Ellipsoid_Code[3] = "AA";
+static constexpr std::size_t BNG_STRING_CAPACITY = 100;
 
 RTTI_DEF1(ossimBngProjection, "ossimBngProjection", ossimMapProjection);
 
@@ -59,7 +60,7 @@ ossimBngProjection::ossimBngProjection()
 
 ossimGpt ossimBngProjection::inverse(const ossimDpt &eastingNorthing)const
 {
-   char s[100];
+   char s[BNG_STRING_CAPACITY];
    double lat;
    double lon;
 
@@ -84,7 +85,7 @@ ossimGpt ossimBngProjection::inverse(const ossimDpt &eastingNorthing)const
 
 ossimDpt ossimBngProjection::forward(const ossimGpt &latLon)const
 {
-   char BNG[100];
+   char BNG[BNG_STRING_CAPACITY];
 
    string_Broken = 0;
    Set_Transverse_Mercator_Parameters(BNG_a, BNG_f, BNG_Origin_Lat,
@@ -244,14 +245,54 @@ long ossimBngProjection::Make_BNG_String (char ltrnum[4],
     east -= 1;
   if ((Precision == 0) && (east == 1))
      east = 0;
-  i += sprintf (BNG + i, "%*.*ld",(int) Precision,(int) Precision, east);
+  auto appendValue = [&](long value) -> bool
+  {
+     if (i < 0)
+     {
+        return false;
+     }
+
+     std::size_t remaining = 0;
+     if (static_cast<std::size_t>(i) < BNG_STRING_CAPACITY)
+     {
+        remaining = BNG_STRING_CAPACITY - static_cast<std::size_t>(i);
+     }
+
+     if (remaining == 0)
+     {
+        return false;
+     }
+
+     const int written = std::snprintf(BNG + i,
+                                       remaining,
+                                       "%*.*ld",
+                                       static_cast<int>(Precision),
+                                       static_cast<int>(Precision),
+                                       value);
+
+     if (written < 0 || static_cast<std::size_t>(written) >= remaining)
+     {
+        return false;
+     }
+
+     i += written;
+     return true;
+  };
+
+  if (!appendValue(east))
+  {
+     return BNG_STRING_ERROR;
+  }
 
   north = Round_BNG (Northing/divisor);
   if (north == unitInterval)
     north -= 1;
   if ((Precision == 0) && (north == 1))
     north = 0;
-  i += sprintf (BNG + i, "%*.*ld",(int)  Precision,(int) Precision, north);
+  if (!appendValue(north))
+  {
+     return BNG_STRING_ERROR;
+  }
 
   return (error_code);
 } /* Make_BNG_String */
@@ -737,6 +778,3 @@ long ossimBngProjection::Convert_BNG_To_Transverse_Mercator(char *BNG,
   }
   return Error_Code;
 } /* END OF Convert_BNG_To_Transverse_Mercator */
-
-
-

--- a/src/projection/ossimCoarseGridModel.cpp
+++ b/src/projection/ossimCoarseGridModel.cpp
@@ -621,12 +621,15 @@ std::ostream& ossimCoarseGridModel::print(std::ostream& out) const
       {
          samp = (int) (node.x*spacing.x);
          
-         sprintf(buf, "[%5d, %5d]    %+9.5f  %+10.5f    %+11.4e  %+11.4e",
-                  line, samp,
-                  theLatGrid.getNode(node),
-                  theLonGrid.getNode(node),
-                  theDlatDhGrid.getNode(node),
-                  theDlonDhGrid.getNode(node));
+         std::snprintf(buf,
+                       sizeof(buf),
+                       "[%5d, %5d]    %+9.5f  %+10.5f    %+11.4e  %+11.4e",
+                       line,
+                       samp,
+                       theLatGrid.getNode(node),
+                       theLonGrid.getNode(node),
+                       theDlatDhGrid.getNode(node),
+                       theDlonDhGrid.getNode(node));
          out << buf << endl;
       }
       out <<"-----------------------------------------------------------------"

--- a/src/projection/ossimIkonosRpcModel.cpp
+++ b/src/projection/ossimIkonosRpcModel.cpp
@@ -16,6 +16,7 @@
 //  $Id: ossimIkonosRpcModel.cpp 23323 2015-05-27 12:53:00Z gpotts $
 
 #include <cstdlib>
+#include <cstdio>
 #include <ossim/projection/ossimIkonosRpcModel.h>
 #include <ossim/base/ossimException.h>
 #include <ossim/base/ossimNotify.h>
@@ -758,7 +759,7 @@ void ossimIkonosRpcModel::parseRpcData(const ossimFilename& data_file)
    keyword = kwbuf;
    for(int i=1; i<=20; i++)
    {
-      sprintf(kwbuf, "%s%d", LINE_NUM_COEFF_KW, i);
+      std::snprintf(kwbuf, sizeof(kwbuf), "%s%d", LINE_NUM_COEFF_KW, i);
       buf = kwl.find(keyword);
       if (!buf)
       {
@@ -770,7 +771,7 @@ void ossimIkonosRpcModel::parseRpcData(const ossimFilename& data_file)
       
       theLineNumCoef[i-1] = atof(buf);
       
-      sprintf(kwbuf, "%s%d", LINE_DEN_COEFF_KW, i);
+      std::snprintf(kwbuf, sizeof(kwbuf), "%s%d", LINE_DEN_COEFF_KW, i);
       buf = kwl.find(keyword);
       if (!buf)
       {
@@ -781,7 +782,7 @@ void ossimIkonosRpcModel::parseRpcData(const ossimFilename& data_file)
       }
       theLineDenCoef[i-1] = atof(buf);
       
-      sprintf(kwbuf, "%s%d", SAMP_NUM_COEFF_KW, i);
+      std::snprintf(kwbuf, sizeof(kwbuf), "%s%d", SAMP_NUM_COEFF_KW, i);
       buf = kwl.find(keyword);
       if (!buf)
       {
@@ -792,7 +793,7 @@ void ossimIkonosRpcModel::parseRpcData(const ossimFilename& data_file)
       }
       theSampNumCoef[i-1] = atof(buf);
       
-      sprintf(kwbuf, "%s%d", SAMP_DEN_COEFF_KW, i);
+      std::snprintf(kwbuf, sizeof(kwbuf), "%s%d", SAMP_DEN_COEFF_KW, i);
       buf = kwl.find(keyword);
       if (!buf)
       {

--- a/src/sockets/ossimToolServer.cpp
+++ b/src/sockets/ossimToolServer.cpp
@@ -9,9 +9,9 @@
 #include <iostream>
 #include <sstream>
 #include <map>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/wait.h>
@@ -249,7 +249,7 @@ bool ossimToolServer::sendFile(const ossimFilename& fname)
 
    // Send file size to the client:
    char size_response[19];
-   sprintf(size_response, "SIZE: %012d", (int) fsize);
+   std::snprintf(size_response, sizeof(size_response), "SIZE: %012d", static_cast<int>(fsize));
    if (_DEBUG_) cout<<"ossimToolServer:"<<__LINE__<<" sending <"<<size_response<<">"<<endl; //TODO REMOVE DEBUG
    writeSocket(size_response, strlen(size_response));
    if (!acknowledgeRcvd())
@@ -258,7 +258,7 @@ bool ossimToolServer::sendFile(const ossimFilename& fname)
    // Send file name to the client:
    char name_response[256];
    memset(name_response, 0, 256);
-   sprintf(name_response, "NAME: %s", fname.file().chars());
+   std::snprintf(name_response, sizeof(name_response), "NAME: %s", fname.file().chars());
    if (_DEBUG_) cout<<"ossimToolServer:"<<__LINE__<<" sending <"<<name_response<<">"<<endl; //TODO REMOVE DEBUG
    writeSocket(name_response, strlen(name_response));
    if (!acknowledgeRcvd())

--- a/src/support_data/ossimFfL5.cpp
+++ b/src/support_data/ossimFfL5.cpp
@@ -72,7 +72,8 @@ void ossimFfL5::readHeaderRevB(const ossimString& header_name)
    int i=0;
    while((theBandsPresentString[i]>='0') && (theBandsPresentString[i]<='9'))
    {
-      sprintf(theBandFileNames[i],"band%c.dat",theBandsPresentString[i]);
+      std::snprintf(theBandFileNames[i], sizeof(theBandFileNames[i]),
+                    "band%c.dat", theBandsPresentString[i]);
       ++i;
    }
    int nbb=i;
@@ -110,19 +111,19 @@ void ossimFfL5::readHeaderRevB(const ossimString& header_name)
    theUsgsMapZone            = theRevb->theUsgsMapZone;
    
    char temps[256];
-   sprintf(temps,"%s %s",theRevb->theUlLon, theRevb->theUlLat);
+   std::snprintf(temps, sizeof(temps), "%s %s", theRevb->theUlLon, theRevb->theUlLat);
    if (convertGeoPoint(temps, theUL_Corner) != ossimErrorCodes::OSSIM_OK) return;
    
-   sprintf(temps,"%s %s",theRevb->theUrLon, theRevb->theUrLat);
+   std::snprintf(temps, sizeof(temps), "%s %s", theRevb->theUrLon, theRevb->theUrLat);
    if (convertGeoPoint(temps, theUR_Corner) != ossimErrorCodes::OSSIM_OK) return;
    
-   sprintf(temps,"%s %s",theRevb->theLrLon, theRevb->theLrLat);
+   std::snprintf(temps, sizeof(temps), "%s %s", theRevb->theLrLon, theRevb->theLrLat);
    if (convertGeoPoint(temps, theLR_Corner) != ossimErrorCodes::OSSIM_OK) return;
    
-   sprintf(temps,"%s %s",theRevb->theLlLon, theRevb->theLlLat);
+   std::snprintf(temps, sizeof(temps), "%s %s", theRevb->theLlLon, theRevb->theLlLat);
    if (convertGeoPoint(temps, theLL_Corner) != ossimErrorCodes::OSSIM_OK) return;        
    
-   sprintf(temps,"%s %s",theRevb->theCenterLon, theRevb->theCenterLat);
+   std::snprintf(temps, sizeof(temps), "%s %s", theRevb->theCenterLon, theRevb->theCenterLat);
    if (convertGeoPoint(temps, theCenterGP) != ossimErrorCodes::OSSIM_OK) return;        
       
    theCenterImagePoint.x     = theRevb->theCenterSample;

--- a/src/support_data/ossimNitfIchipbTag.cpp
+++ b/src/support_data/ossimNitfIchipbTag.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <cstdio>
 
 static const ossimString XFRM_FLAG_KW = "XFRM_FLAG";
 static const ossimString SCALE_FACTOR_KW = "SCALE_FACTOR";
@@ -571,25 +572,25 @@ bool ossimNitfIchipbTag::initFromGeometry(const ossimImageGeometry* geom)
    if (imageArea <= FLT_EPSILON)
       return false;
    double scaleFactor = sqrt(viewRect.area() / imageArea);
-   sprintf(theScaleFactor, "%10.5f", scaleFactor);
+   std::snprintf(theScaleFactor, sizeof(theScaleFactor), "%10.5f", scaleFactor);
 
-   sprintf(theOpCol11, "%12.3f", viewRect.ul().x);
-   sprintf(theOpRow11, "%12.3f", viewRect.ul().y);
-   sprintf(theOpCol12, "%12.3f", viewRect.ur().x);
-   sprintf(theOpRow12, "%12.3f", viewRect.ur().y);
-   sprintf(theOpCol21, "%12.3f", viewRect.ll().x);
-   sprintf(theOpRow21, "%12.3f", viewRect.ll().y);
-   sprintf(theOpCol22, "%12.3f", viewRect.lr().x);
-   sprintf(theOpRow22, "%12.3f", viewRect.lr().y);
+   std::snprintf(theOpCol11, sizeof(theOpCol11), "%12.3f", viewRect.ul().x);
+   std::snprintf(theOpRow11, sizeof(theOpRow11), "%12.3f", viewRect.ul().y);
+   std::snprintf(theOpCol12, sizeof(theOpCol12), "%12.3f", viewRect.ur().x);
+   std::snprintf(theOpRow12, sizeof(theOpRow12), "%12.3f", viewRect.ur().y);
+   std::snprintf(theOpCol21, sizeof(theOpCol21), "%12.3f", viewRect.ll().x);
+   std::snprintf(theOpRow21, sizeof(theOpRow21), "%12.3f", viewRect.ll().y);
+   std::snprintf(theOpCol22, sizeof(theOpCol22), "%12.3f", viewRect.lr().x);
+   std::snprintf(theOpRow22, sizeof(theOpRow22), "%12.3f", viewRect.lr().y);
 
-   sprintf(theFiCol11, "%12.3f", ul.x);
-   sprintf(theFiRow11, "%12.3f", ul.y);
-   sprintf(theFiCol12, "%12.3f", ur.x);
-   sprintf(theFiRow12, "%12.3f", ur.y);
-   sprintf(theFiCol21, "%12.3f", ll.x);
-   sprintf(theFiRow21, "%12.3f", ll.y);
-   sprintf(theFiCol22, "%12.3f", lr.x);
-   sprintf(theFiRow22, "%12.3f", lr.y);
+   std::snprintf(theFiCol11, sizeof(theFiCol11), "%12.3f", ul.x);
+   std::snprintf(theFiRow11, sizeof(theFiRow11), "%12.3f", ul.y);
+   std::snprintf(theFiCol12, sizeof(theFiCol12), "%12.3f", ur.x);
+   std::snprintf(theFiRow12, sizeof(theFiRow12), "%12.3f", ur.y);
+   std::snprintf(theFiCol21, sizeof(theFiCol21), "%12.3f", ll.x);
+   std::snprintf(theFiRow21, sizeof(theFiRow21), "%12.3f", ll.y);
+   std::snprintf(theFiCol22, sizeof(theFiCol22), "%12.3f", lr.x);
+   std::snprintf(theFiRow22, sizeof(theFiRow22), "%12.3f", lr.y);
 
    return true;
 }
@@ -855,4 +856,3 @@ bool ossimNitfIchipbTag::loadState(const ossimKeywordlist& kwl, const char* pref
 
    return true;
 }
-

--- a/test/src/imaging/ossim-remap-table-test.cpp
+++ b/test/src/imaging/ossim-remap-table-test.cpp
@@ -118,9 +118,12 @@ int main(int argc, char *argv[])
    n = s16tbl.normFromPix(p);
    cout << "normFromPix(" << p << "): " << n << "\n";
 
-   p = 32766.99999999999;
-   n = s16tbl.normFromPix(p);
-   cout << "normFromPix(" << p << "): " << n << "\n";
+   {
+      const ossim_float64 val = 32766.99999999999;
+      p = static_cast<ossim_int32>(val);
+      n = s16tbl.normFromPix(p);
+      cout << "normFromPix(" << val << "): " << n << "\n";
+   }
 
    p = 32767;
    n = s16tbl.normFromPix(p);


### PR DESCRIPTION
…to quiet AppleClang warnings (ossim/include/ossim/base/ossimRtti.h:339, ossim/include/ossim/projection/ossimLlxyProjection.h:32). Replaced legacy connectable-object search helpers with visitor-based traversals in the mosaic app and view controller so deprecated APIs can be silenced without removing them (ossim/apps/ossim-mosaic/ossim-mosaic.cpp:106, ossim/src/base/ossimViewController.cpp:66). Hardened formatting/IO by swapping sprintf/hard-coded formats for safe variants (ossim/src/base/ossimDms.cpp:541, ossim/apps/ossim-plot-histo/ossim-plot-histo.cpp:95) and standard exit codes in utilities (ossim/apps/ossim-swapbytes/ossim-swapbytes.cpp:35). Wrapped deprecated findAllObjectsOfType definitions with Clang pragma guards and tweaked supporting code/tests to avoid narrowing conversions (ossim/src/base/ossimConnectableContainer.cpp:99, ossim/test/src/imaging/ossim-remap-table-test.cpp:118).