### PR TITLE
Phase 1 build updates:

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.16...3.26)
 
 PROJECT(ossimlabs)
 
@@ -49,11 +49,7 @@ INCLUDE(OssimCommonVariables)
 FILE(REMOVE ${CMAKE_INCLUDE_DIRS_FILE})
 FILE(REMOVE ${CMAKE_FILENAMES_FILE})
 
-IF(NOT APPLE)
-  cmake_minimum_required(VERSION 2.6)
-ELSE(NOT APPLE)
-    cmake_minimum_required(VERSION 2.8)
-ENDIF(NOT APPLE)
+# Do not downgrade the CMake policy/version in subtrees
 
 IF(EXISTS "$ENV{OSSIM_DEPENDENCIES}")
    SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${OSSIM_DEPENDENCIES}/include )

--- a/cmake/CMakeModules/FindFFmpeg.cmake
+++ b/cmake/CMakeModules/FindFFmpeg.cmake
@@ -133,6 +133,11 @@ IF   (FFMPEG_LIBAVFORMAT_FOUND AND FFMPEG_LIBAVDEVICE_FOUND AND FFMPEG_LIBAVCODE
          ${FFMPEG_LIBAVFILTER_INCLUDE_DIRS}
          ${FFMPEG_LIBSWRESAMPLE_INCLUDE_DIRS} )
 
+    # Deduplicate include directories to avoid repeated paths in logs/build flags
+    if (FFMPEG_INCLUDE_DIRS)
+        list(REMOVE_DUPLICATES FFMPEG_INCLUDE_DIRS)
+    endif()
+
     SET(FFMPEG_LIBRARY_DIRS ${FFMPEG_LIBAVFORMAT_LIBRARY_DIRS})
 
     # Note we don't add FFMPEG_LIBSWSCALE_LIBRARIES here, it will be added if found later.

--- a/cmake/CMakeModules/Findossim.cmake
+++ b/cmake/CMakeModules/Findossim.cmake
@@ -12,20 +12,35 @@
 #  OSSIM_LIBRARY, where to find the OSSIM library.
 #---
 
-#---
-# Find include path:
-#---
-set(CMAKE_FIND_FRAMEWORK "LAST")
-find_path(OSSIM_INCLUDE_DIR ossim/ossimVersion.h ossimVersion.h
-          PATHS
-          $ENV{OSSIM_DEV_HOME}/ossim/include
-          $ENV{OSSIM_INSTALL_PREFIX}/include )
+# If building in the same CMake project, prefer the ossim target directly
+if (TARGET ossim)
+  # Use known include path from the dev tree if available
+  if (DEFINED OSSIM_DEV_HOME)
+    set(OSSIM_INCLUDE_DIR "${OSSIM_DEV_HOME}/ossim/include")
+  elseif(DEFINED ENV{OSSIM_DEV_HOME})
+    set(OSSIM_INCLUDE_DIR "$ENV{OSSIM_DEV_HOME}/ossim/include")
+  endif()
+  set(OSSIM_LIBRARY ossim)
+  set(OSSIM_LIBRARIES ossim)
+else()
+  #---
+  # Find include path:
+  #---
+  set(CMAKE_FIND_FRAMEWORK "LAST")
+  find_path(OSSIM_INCLUDE_DIR ossim/ossimVersion.h ossimVersion.h
+            PATHS
+            $ENV{OSSIM_DEV_HOME}/ossim/include
+            $ENV{OSSIM_INSTALL_PREFIX}/include )
 
-set(OSSIM_NAMES ${OSSIM_NAMES} ossim libossim)
-find_library(OSSIM_LIBRARY NAMES ${OSSIM_NAMES}
-             PATHS
-             $ENV{OSSIM_BUILD_DIR}/lib
-             $ENV{OSSIM_INSTALL_PREFIX}/lib)
+  set(OSSIM_NAMES ${OSSIM_NAMES} ossim libossim)
+  find_library(OSSIM_LIBRARY NAMES ${OSSIM_NAMES}
+               PATHS
+               $ENV{OSSIM_BUILD_DIR}/lib64
+               $ENV{OSSIM_BUILD_DIR}/lib
+               $ENV{OSSIM_INSTALL_PREFIX}/lib64
+               $ENV{OSSIM_INSTALL_PREFIX}/lib)
+  set(OSSIM_LIBRARIES ${OSSIM_LIBRARY})
+endif()
 
 #---
 # This function sets OSSIM_FOUND if variables are valid.
@@ -36,13 +51,12 @@ find_package_handle_standard_args( ossim DEFAULT_MSG
                                    OSSIM_INCLUDE_DIR )
 
 if(OSSIM_FOUND)
-   set( OSSIM_LIBRARIES ${OSSIM_LIBRARY} )
    set( OSSIM_INCLUDES  ${OSSIM_INCLUDE_DIR} )
-else( OSSIM_FOUND )
+else()
    if( NOT OSSIM_FIND_QUIETLY )
       message( WARNING "Could not find OSSIM" )
-   endif( NOT OSSIM_FIND_QUIETLY )
-endif(OSSIM_FOUND)
+   endif()
+endif()
 
 if( NOT OSSIM_FIND_QUIETLY )
    message( STATUS "OSSIM_INCLUDE_DIR=${OSSIM_INCLUDE_DIR}" )

--- a/cmake/CMakeModules/OssimUtilities.cmake
+++ b/cmake/CMakeModules/OssimUtilities.cmake
@@ -322,6 +322,10 @@ MACRO(OSSIM_LINK_LIBRARY)
    SET_TARGET_PROPERTIES(${LINK_NAME} PROPERTIES 
                               ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${BUILD_LIBRARY_DIR}")    
 
+   # Ensure core 'ossim' target is built before linking libraries that depend on it
+   if (TARGET ossim)
+     add_dependencies(${LINK_NAME} ossim)
+   endif()
    TARGET_LINK_LIBRARIES(${LINK_NAME} ${LINK_LIBRARIES} ${${LINK_NAME}_EXTRA_LIBS})
 
    IF(LINK_INSTALL_LIB)

--- a/cmake/scripts/ossim-cmake-config.sh
+++ b/cmake/scripts/ossim-cmake-config.sh
@@ -217,8 +217,17 @@ if [ "${BUILD_OSSIM_GUI}" == "ON" ]; then
   if [ -z $QT_CMAKE_DIR ]; then
     if [ -d "/usr/lib64/cmake/Qt5Core" ]; then
       export QT_CMAKE_DIR="/usr/lib64/cmake" 
+    elif [ -d "/usr/lib/x86_64-linux-gnu/cmake/Qt5Core" ]; then
+      # Debian/Ubuntu multiarch path
+      export QT_CMAKE_DIR="/usr/lib/x86_64-linux-gnu/cmake"
     elif [ -d "/usr/local/opt/qt5/lib/cmake" ]; then
       export QT_CMAKE_DIR="/usr/local/opt/qt5/lib/cmake"
+    elif [ -d "/opt/local/lib/cmake/Qt5Core" ]; then
+      # MacPorts Qt5 (modern layout)
+      export QT_CMAKE_DIR="/opt/local/lib/cmake"
+    elif [ -d "/opt/local/libexec/qt5/lib/cmake" ]; then
+      # MacPorts Qt5 (older layout)
+      export QT_CMAKE_DIR="/opt/local/libexec/qt5/lib/cmake"
     fi
   fi   
   if [ -z $Qt5Core_DIR ]; then
@@ -231,6 +240,13 @@ if [ "${BUILD_OSSIM_GUI}" == "ON" ]; then
 
   if [ -z $Qt5OpenGL_DIR ]; then
     export Qt5OpenGL_DIR=${QT_CMAKE_DIR}/Qt5OpenGL
+  fi
+
+  # Ensure pkg-config can see MacPorts libraries (Qt5 and FFmpeg)
+  if [ -z "$PKG_CONFIG_PATH" ]; then
+    export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:/opt/local/lib/pkgconfig:/opt/local/lib/proj9/lib/pkgconfig"
+  else
+    export PKG_CONFIG_PATH="/opt/local/libexec/qt5/lib/pkgconfig:/opt/local/lib/pkgconfig:/opt/local/lib/proj9/lib/pkgconfig:$PKG_CONFIG_PATH"
   fi
 fi
 
@@ -307,4 +323,3 @@ $CMAKE_DIR
 
 echo CMAKE_COMMAND: $CMAKE_COMMAND
 popd >/dev/null
-


### PR DESCRIPTION
- CMake policy range 3.16...3.26 (consistent, modern behavior)
- Qt/PROJ MacPorts detection in config script; add pkg-config paths
- FFmpeg find-module: deduplicate include dirs
- Findossim: prefer in-tree target; search lib64
- Ensure libs built via OSSIM_LINK_LIBRARY depend on core 'ossim' target