### PR TITLE
Fix include paths

### DIFF
--- a/src/support_data/ossimNitfGenericTag.cpp
+++ b/src/support_data/ossimNitfGenericTag.cpp
@@ -13,8 +13,8 @@
 #include <ossim/support_data/ossimNitfCommon.h>
 #include <ossim/base/ossimKeywordlist.h>
 #include <ossim/base/ossimNotify.h>
-#include <base/ossimException.h>
-#include <base/ossimTrace.h>
+#include <ossim/base/ossimException.h>
+#include <ossim/base/ossimTrace.h>
 
 #include <istream>
 #include <iostream>

--- a/src/support_data/ossimNitfRegisteredDesFactory.cpp
+++ b/src/support_data/ossimNitfRegisteredDesFactory.cpp
@@ -17,7 +17,7 @@
 #include <ossim/support_data/ossimNitfCscsdbDes.h>
 #include <ossim/support_data/ossimNitfCssfabDes.h>
 
-#include "support_data/ossimNitfCsephbDes.h"
+#include <ossim/support_data/ossimNitfCsephbDes.h>
 
 RTTI_DEF1(ossimNitfRegisteredDesFactory, "ossimNitfRegisteredDesFactory", ossimNitfDesFactory);
 

--- a/src/support_data/ossimNitfXmlTag.cpp
+++ b/src/support_data/ossimNitfXmlTag.cpp
@@ -14,7 +14,7 @@
 #include <ossim/support_data/ossimNitfXmlTag.h>
 #include <iomanip>
 #include <sstream>
-#include <base/ossimPreferences.h>
+#include <ossim/base/ossimPreferences.h>
 
 ossimNitfXmlTag::ossimNitfXmlTag(ossimString tagName)
    : ossimNitfRegisteredTag(tagName, 0)


### PR DESCRIPTION
Fix issues like this during a build:

```
/build/source/src/support_data/ossimNitfGenericTag.cpp:16:10: fatal error: base/ossimException.h: No such file or directory
   16 | #include <base/ossimException.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```